### PR TITLE
Don't load PosteriorStats in doctests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorStats"
 uuid = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -33,7 +33,7 @@ Compare the centered and non centered models of the eight school problem using t
 as expected by [`loo`](@ref).
 
 ```jldoctest compare; filter = [r"└.*"]
-julia> using ArviZExampleData, PosteriorStats
+julia> using ArviZExampleData
 
 julia> models = (
            centered=load_example_data("centered_eight"),

--- a/src/hdi.jl
+++ b/src/hdi.jl
@@ -32,8 +32,6 @@ This implementation uses the algorithm of [^ChenShao1999].
 Here we calculate the 83% HDI for a normal random variable:
 
 ```jldoctest hdi; setup = :(using Random; Random.seed!(78))
-julia> using PosteriorStats
-
 julia> x = randn(2_000);
 
 julia> hdi(x; prob=0.83) |> pairs

--- a/src/loo.jl
+++ b/src/loo.jl
@@ -60,7 +60,7 @@ See also: [`PSISLOOResult`](@ref), [`waic`](@ref)
 Manually compute ``R_\\mathrm{eff}`` and calculate PSIS-LOO of a model:
 
 ```jldoctest
-julia> using ArviZExampleData, MCMCDiagnosticTools, PosteriorStats
+julia> using ArviZExampleData, MCMCDiagnosticTools
 
 julia> idata = load_example_data("centered_eight");
 

--- a/src/loo_pit.jl
+++ b/src/loo_pit.jl
@@ -45,7 +45,7 @@ LOO-PIT values should be approximately uniformly distributed on ``[0, 1]``.[^Gab
 Calculate LOO-PIT values using as test quantity the observed values themselves.
 
 ```jldoctest loo_pit1
-julia> using ArviZExampleData, PosteriorStats
+julia> using ArviZExampleData
 
 julia> idata = load_example_data("centered_eight");
 

--- a/src/model_weights.jl
+++ b/src/model_weights.jl
@@ -36,7 +36,7 @@ See also: [`AbstractModelWeightsMethod`](@ref), [`compare`](@ref)
 Compute [`Stacking`](@ref) weights for two models:
 
 ```jldoctest model_weights; filter = [r"└.*"]
-julia> using ArviZExampleData, PosteriorStats
+julia> using ArviZExampleData
 
 julia> models = (
            centered=load_example_data("centered_eight"),

--- a/src/r2_score.jl
+++ b/src/r2_score.jl
@@ -16,7 +16,7 @@
 # Examples
 
 ```jldoctest
-julia> using ArviZExampleData, PosteriorStats
+julia> using ArviZExampleData
 
 julia> idata = load_example_data("regression1d");
 

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -110,7 +110,7 @@ See also [`SummaryStats`](@ref), [`default_summary_stats`](@ref), [`default_stat
 Compute `mean`, `std` and the Monte Carlo standard error (MCSE) of the mean estimate:
 
 ```jldoctest summarize; setup = (using Random; Random.seed!(84))
-julia> using PosteriorStats, Statistics, StatsBase
+julia> using Statistics, StatsBase
 
 julia> x = randn(1000, 4, 3) .+ reshape(0:10:20, 1, 1, :);
 

--- a/src/waic.jl
+++ b/src/waic.jl
@@ -46,7 +46,7 @@ See also: [`WAICResult`](@ref), [`loo`](@ref)
 Calculate WAIC of a model:
 
 ```jldoctest
-julia> using ArviZExampleData, PosteriorStats
+julia> using ArviZExampleData
 
 julia> idata = load_example_data("centered_eight");
 


### PR DESCRIPTION
This PR removes `using PosteriorStats` from all doctests.