### PR TITLE
Fix RCall set-up for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,8 +46,6 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Build Conda
         run: |
           using Pkg; Pkg.activate(; temp=true);

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,8 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
       - name: Set R lib path for RCall.jl
         if: matrix.os == 'ubuntu-latest'
-        run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib" >> $GITHUB_ENV
+        run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - name: Install R packages
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,12 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
+      - name: Build Conda
+        run: |
+          using Pkg; Pkg.activate(; temp=true);
+          Pkg.add("Conda");
+          Pkg.build("Conda");
+        shell: julia --color=yes {0}
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
RCall suddenly started failing to build in CI, with the error `ERROR: LoadError: ArgumentError: Path to conda environment is not valid: /home/runner/.julia/conda/3/x86_64`, see e.g. https://github.com/arviz-devs/PosteriorStats.jl/actions/runs/5798164513/job/15937131562#step:9:66.

This PR attempts to fix CI.