### PR TITLE
Simple improvements to summary utilities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorStats"
 uuid = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -297,7 +297,8 @@ function default_diagnostics(::typeof(Statistics.median); kwargs...)
     ess_tail_kwargs = (ess_kwargs..., filter(k -> k === :tail_prob, kwargs)...)
     rhat_kwargs = filter(k -> k === :split_chains, ess_kwargs)
     return (
-        :mcse_median => FixKeywords(mcse_median; kind=Statistics.median, ess_kwargs...),
+        :mcse_median =>
+            FixKeywords(MCMCDiagnosticTools.mcse; kind=Statistics.median, ess_kwargs...),
         :ess_tail =>
             FixKeywords(MCMCDiagnosticTools.ess_tail; kind=:tail, ess_tail_kwargs...),
         :ess_median =>

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -299,8 +299,7 @@ function default_diagnostics(::typeof(Statistics.median); kwargs...)
     return (
         :mcse_median =>
             FixKeywords(MCMCDiagnosticTools.mcse; kind=Statistics.median, ess_kwargs...),
-        :ess_tail =>
-            FixKeywords(MCMCDiagnosticTools.ess; kind=:tail, ess_tail_kwargs...),
+        :ess_tail => FixKeywords(MCMCDiagnosticTools.ess; kind=:tail, ess_tail_kwargs...),
         :ess_median =>
             FixKeywords(MCMCDiagnosticTools.ess; kind=Statistics.median, ess_kwargs...),
         :rhat => FixKeywords(MCMCDiagnosticTools.rhat; rhat_kwargs...),

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -300,7 +300,7 @@ function default_diagnostics(::typeof(Statistics.median); kwargs...)
         :mcse_median =>
             FixKeywords(MCMCDiagnosticTools.mcse; kind=Statistics.median, ess_kwargs...),
         :ess_tail =>
-            FixKeywords(MCMCDiagnosticTools.ess_tail; kind=:tail, ess_tail_kwargs...),
+            FixKeywords(MCMCDiagnosticTools.ess; kind=:tail, ess_tail_kwargs...),
         :ess_median =>
             FixKeywords(MCMCDiagnosticTools.ess; kind=Statistics.median, ess_kwargs...),
         :rhat => FixKeywords(MCMCDiagnosticTools.rhat; rhat_kwargs...),

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -216,7 +216,7 @@ end
 """
     default_summary_stats(focus=Statistics.mean; kwargs...)
 
-Combinatiton of [`default_stats`](@ref) and [`default_diagnostics`](@ref) to be used with
+Combination of [`default_stats`](@ref) and [`default_diagnostics`](@ref) to be used with
 [`summarize`](@ref).
 """
 function default_summary_stats(focus=Statistics.mean; kwargs...)

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -41,6 +41,11 @@ end
 
 #### custom tabular show methods
 
+function Base.show(io::IO, stats::SummaryStats)
+    nrows = length(first(stats))
+    ncols = length(stats)
+    print(io, stats.name, " ($nrows rows, $ncols cols)")
+end
 function Base.show(io::IO, mime::MIME"text/plain", stats::SummaryStats; kwargs...)
     return _show(io, mime, stats; kwargs...)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,16 @@
+"""
+    FixKeywords(f; kwargs...)
+    FixKeywords(f, kwargs)
+
+A type representing the function `(xs...) -> f(xs...; kwargs...)`.
+"""
+struct FixKeywords{F}
+    f::F
+    kwargs
+end
+FixKeywords(f; kwargs...) = FixKeywords(f, kwargs)
+(f::FixKeywords)(args...) = f.f(args...; f.kwargs...)
+
 function _check_log_likelihood(x)
     if any(!isfinite, x)
         @warn "All log likelihood values must be finite, but some are not."


### PR DESCRIPTION
This PR primarily updates the sets of default summary statistics to be configurable with the keywords of each set of statistics. e.g. `autocov_method` is now accepted to `default_diagnostics` and is passed to `ess`.

It also adds a fallback `show` method for `SummaryStats`.