### PR TITLE
Fix showing of pretty tables on x86

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorStats"
 uuid = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -331,7 +331,7 @@ function _show_prettytable(
     newline_at_end=false,
     kwargs...,
 )
-    alignment_anchor_regex = Dict{Int64,Vector{Regex}}(
+    alignment_anchor_regex = Dict{Int,Vector{Regex}}(
         i => [r"\.", r"e", r"^NaN$", r"Inf$"] for (i, (k, v)) in enumerate(pairs(data)) if
         (eltype(v) <: Real && !(eltype(v) <: Integer) && !_is_ess_label(k))
     )


### PR DESCRIPTION
Replaces a hardcoded `Int64` with `Int` so that it works correctly on x86 systems.