### PR TITLE
 Update doctests for DimensionalData v0.26 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorStats"
 uuid = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/loo_pit.jl
+++ b/src/loo_pit.jl
@@ -58,8 +58,11 @@ julia> log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :s
 julia> log_weights = loo(log_like).psis_result.log_weights;
 
 julia> loo_pit(y, y_pred, log_weights)
-8-element DimArray{Float64,1} with dimensions:
-  Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
+╭───────────────────────────────╮
+│ 8-element DimArray{Float64,1} │
+├───────────────────────────────┴──────────────────────────────────────── dims ┐
+  ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
+└──────────────────────────────────────────────────────────────────────────────┘
  "Choate"            0.943511
  "Deerfield"         0.63797
  "Phillips Andover"  0.316697
@@ -83,8 +86,11 @@ julia> T = y .- median(mu);
 julia> T_pred = y_pred .- mu;
 
 julia> loo_pit(T .^ 2, T_pred .^ 2, log_weights)
-8-element DimArray{Float64,1} with dimensions:
-  Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
+╭───────────────────────────────╮
+│ 8-element DimArray{Float64,1} │
+├───────────────────────────────┴──────────────────────────────────────── dims ┐
+  ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
+└──────────────────────────────────────────────────────────────────────────────┘
  "Choate"            0.873577
  "Deerfield"         0.243686
  "Phillips Andover"  0.357563


### PR DESCRIPTION
DimensionalData v0.26 changed the representation of `DimArray`s in the REPL, so this PR updates the docstrings accordingly.