### PR TITLE
Replace generated function with `nameof`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorStats"
 uuid = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -400,12 +400,7 @@ end
 _fun_and_name(p::Pair) = p
 _fun_and_name(f) = nothing => f
 
-_fname(f) = Symbol(_fname_string(f))
-@generated function _fname_string(::F) where {F}
-    s = replace(string(F), r"^typeof\((.*)\)$" => s"\1")
-    # remove module name
-    return replace(s, r"^.*\.(.*)$" => s"\1")
-end
+_fname(f) = nameof(f)
 
 # curried functions
 _mcse_std(x) = MCMCDiagnosticTools.mcse(x; kind=Statistics.std)


### PR DESCRIPTION
As suggested in https://github.com/JuliaLang/julia/issues/54780#issuecomment-2269928520, this PR replaces the generated function `_fname` with just `nameof`.

This should resolve recent failures on the Julia nightly CI.