### PR TITLE
Make unimodal HDI more efficient

### DIFF
--- a/src/hdi.jl
+++ b/src/hdi.jl
@@ -110,8 +110,16 @@ function _hdi_sort!(x, interval_length, npoints_to_check)
     if npoints_to_check < interval_length - 1
         ifirst = firstindex(x)
         iend = lastindex(x)
-        partialsort!(x, ifirst:(ifirst - 1 + npoints_to_check))
-        partialsort!(x, (ifirst - 1 + interval_length):iend)
+        # first sort the lower tail in-place
+        sort!(x; alg=Base.Sort.PartialQuickSort(ifirst:(ifirst - 1 + npoints_to_check)))
+        # now sort the upper tail, avoiding modifying the lower tail
+        x_upper = @view x[(ifirst + npoints_to_check):iend]
+        sort!(
+            x_upper;
+            alg=Base.Sort.PartialQuickSort((
+                (interval_length - npoints_to_check):(iend - ifirst + 1 - npoints_to_check)
+            )),
+        )
     else
         sort!(x)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -66,6 +66,13 @@ function _assimilar(x::NamedTuple, y)
     return z
 end
 
+# included since Base.copymutable is not public
+function _copymutable(x::AbstractArray)
+    y = similar(x)
+    copyto!(y, x)
+    return y
+end
+
 function _skipmissing(x::AbstractArray)
     Missing <: eltype(x) && return skipmissing(x)
     return x

--- a/test/hdi.jl
+++ b/test/hdi.jl
@@ -8,10 +8,12 @@ using Test
     @testset "AbstractVector" begin
         @testset for n in (10, 100, 1_000),
             prob in (1 / n, 0.5, 0.73, 0.96, (n - 1 + 0.1) / n),
-            T in (Float32, Float64, Int64)
+            T in (Float32, Float64, Int64),
+            sorted in (true, false)
 
             x = T <: Integer ? rand(T(1):T(30), n) : randn(T, n)
-            r = @inferred hdi(x; prob)
+            xsort = sort(x)
+            r = @inferred hdi(sorted ? xsort : x; prob, sorted)
             @test r isa ClosedInterval{T}
             l, u = IntervalSets.endpoints(r)
             interval_length = floor(Int, prob * n) + 1
@@ -20,13 +22,12 @@ using Test
             else
                 @test sum(x -> l ≤ x ≤ u, x) == interval_length
             end
-            xsort = sort(x)
             lind = 1:(n - interval_length + 1)
             uind = interval_length:n
             @assert all(collect(uind) .- collect(lind) .+ 1 .== interval_length)
             @test minimum(xsort[uind] - xsort[lind]) ≈ u - l
 
-            @test hdi!(copy(x); prob) == r
+            @test hdi!(sorted ? xsort : x; prob, sorted) == r
         end
     end
 


### PR DESCRIPTION
This adds a few speed-ups to `hdi`:
- Since `hdi` only needs the left and right tails to be sorted, when the two don't overlap partial sorting is now used. Relative efficiency increases with `n` and `prob`. (note that `eti` already takes a similar approach, since `quantile` uses partial sorting, but in this case, the indices of the points in the interval must be partially sorted, so relative efficiency of `eti` increases with _decreasing_ `prob`)
- It now accepts a `sorted` keyword so that sorting (and copying) can be completely avoided for already-sorted arrays.