### PR TITLE
Update doctests for new ArviZExampleData

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-downgrade-compat@v1
         with:
-          skip: LinearAlgebra,Markdown,Printf,Random,Statistics
+          skip: LinearAlgebra,Markdown,Printf,Random,Statistics,ArviZExampleData
         if: ${{ matrix.downgrade }}
         name: Downgrade dependencies to oldest supported versions
       - uses: julia-actions/julia-buildpkg@v1

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -32,7 +32,7 @@ Compare the centered and non centered models of the eight school problem using t
 [`loo`](@ref) and [`Stacking`](@ref) weights. A custom `myloo` method formates the inputs
 as expected by [`loo`](@ref).
 
-```jldoctest compare; filter = [r"└.*"]
+```jldoctest compare; filter = [r"└.*", r"(\\d+\\.\\d{3})\\d*" => s"\\1"]
 julia> using ArviZExampleData
 
 julia> models = (

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -50,8 +50,8 @@ julia> mc = compare(models; elpd_method=myloo)
 └ @ PSIS ~/.julia/packages/PSIS/...
 ModelComparisonResult with Stacking weights
                rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p   ⋯
- non_centered     1   -31        1.4       0              0.0       1.0  0.9   ⋯
- centered         2   -31        1.4       0.06           0.067     0.0  0.9   ⋯
+ non_centered     1   -31        1.5       0              0.0       1.0  0.9   ⋯
+ centered         2   -31        1.4       0.03           0.061     0.0  0.9   ⋯
                                                                 1 column omitted
 julia> mc.weight |> pairs
 pairs(::NamedTuple) with 2 entries:
@@ -68,8 +68,8 @@ julia> elpd_results = mc.elpd_result;
 julia> compare(elpd_results; weights_method=BootstrappedPseudoBMA())
 ModelComparisonResult with BootstrappedPseudoBMA weights
                rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p   ⋯
- non_centered     1   -31        1.4       0              0.0      0.52  0.9   ⋯
- centered         2   -31        1.4       0.06           0.067    0.48  0.9   ⋯
+ non_centered     1   -31        1.5       0              0.0      0.51  0.9   ⋯
+ centered         2   -31        1.4       0.03           0.061    0.49  0.9   ⋯
                                                                 1 column omitted
 ```
 

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -56,7 +56,7 @@ ModelComparisonResult with Stacking weights
 julia> mc.weight |> pairs
 pairs(::NamedTuple) with 2 entries:
   :non_centered => 1.0
-  :centered     => 5.34175e-19
+  :centered     => 3.50546e-31
 ```
 
 Compare the same models from pre-computed PSIS-LOO results and computing

--- a/src/loo.jl
+++ b/src/loo.jl
@@ -64,13 +64,13 @@ julia> reff = ess(log_like; kind=:basic, split_chains=1, relative=true);
 julia> loo(log_like; reff)
 PSISLOOResult with estimates
  elpd  elpd_mcse    p  p_mcse
-  -31        1.4  0.9    0.34
+  -31        1.4  0.9    0.33
 
 and PSISResult with 500 draws, 4 chains, and 8 parameters
 Pareto shape (k) diagnostic values:
                     Count      Min. ESS
- (-Inf, 0.5]  good  7 (87.5%)  151
-  (0.5, 0.7]  okay  1 (12.5%)  446
+ (-Inf, 0.5]  good  5 (62.5%)  290
+  (0.5, 0.7]  okay  3 (37.5%)  399
 ```
 
 # References

--- a/src/loo_pit.jl
+++ b/src/loo_pit.jl
@@ -55,14 +55,14 @@ julia> log_weights = loo(log_like).psis_result.log_weights;
 julia> loo_pit(y, y_pred, log_weights)
 8-element DimArray{Float64,1} with dimensions:
   Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
- "Choate"            0.943511
- "Deerfield"         0.63797
- "Phillips Andover"  0.316697
- "Phillips Exeter"   0.582252
- "Hotchkiss"         0.295321
- "Lawrenceville"     0.403318
- "St. Paul's"        0.902508
- "Mt. Hermon"        0.655275
+ "Choate"            0.942759
+ "Deerfield"         0.641057
+ "Phillips Andover"  0.32729
+ "Phillips Exeter"   0.581451
+ "Hotchkiss"         0.288523
+ "Lawrenceville"     0.393741
+ "St. Paul's"        0.886175
+ "Mt. Hermon"        0.638821
 ```
 
 Calculate LOO-PIT values using as test quantity the square of the difference between
@@ -80,14 +80,14 @@ julia> T_pred = y_pred .- mu;
 julia> loo_pit(T .^ 2, T_pred .^ 2, log_weights)
 8-element DimArray{Float64,1} with dimensions:
   Dim{:school} Categorical{String} String[Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
- "Choate"            0.873577
- "Deerfield"         0.243686
- "Phillips Andover"  0.357563
- "Phillips Exeter"   0.149908
- "Hotchkiss"         0.435094
- "Lawrenceville"     0.220627
- "St. Paul's"        0.775086
- "Mt. Hermon"        0.296706
+ "Choate"            0.868148
+ "Deerfield"         0.27421
+ "Phillips Andover"  0.321719
+ "Phillips Exeter"   0.193169
+ "Hotchkiss"         0.370422
+ "Lawrenceville"     0.195601
+ "St. Paul's"        0.817408
+ "Mt. Hermon"        0.326795
 ```
 
 # References

--- a/src/model_weights.jl
+++ b/src/model_weights.jl
@@ -29,7 +29,7 @@ See also: [`AbstractModelWeightsMethod`](@ref), [`compare`](@ref)
 
 Compute [`Stacking`](@ref) weights for two models:
 
-```jldoctest model_weights; filter = [r"└.*"]
+```jldoctest model_weights; filter = [r"└.*", r"(\\d+\\.\\d{3})\\d*" => s"\\1"]
 julia> using ArviZExampleData
 
 julia> models = (

--- a/src/model_weights.jl
+++ b/src/model_weights.jl
@@ -55,8 +55,8 @@ Now we compute [`BootstrappedPseudoBMA`](@ref) weights for the same models:
 ```jldoctest model_weights; setup = :(using Random; Random.seed!(94))
 julia> model_weights(elpd_results; method=BootstrappedPseudoBMA()) |> pairs
 pairs(::NamedTuple) with 2 entries:
-  :centered     => 0.483727
-  :non_centered => 0.516273
+  :centered     => 0.492513
+  :non_centered => 0.507487
 ```
 
 # References

--- a/src/model_weights.jl
+++ b/src/model_weights.jl
@@ -46,7 +46,7 @@ julia> elpd_results = map(models) do idata
 
 julia> model_weights(elpd_results; method=Stacking()) |> pairs
 pairs(::NamedTuple) with 2 entries:
-  :centered     => 5.34175e-19
+  :centered     => 3.50546e-31
   :non_centered => 1.0
 ```
 

--- a/src/waic.jl
+++ b/src/waic.jl
@@ -47,7 +47,7 @@ julia> log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :s
 julia> waic(log_like)
 WAICResult with estimates
  elpd  elpd_mcse    p  p_mcse
-  -31        1.4  0.9    0.33
+  -31        1.4  0.9    0.32
 ```
 
 # References

--- a/test/compare.jl
+++ b/test/compare.jl
@@ -112,14 +112,14 @@ end
             @test sprint(show, "text/plain", mc1) == """
                 ModelComparisonResult with Stacking weights
                                rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
-                 non_centered     1   -31        1.4       0              0.0       1.0  0.9    0.32
-                 centered         2   -31        1.4       0.06           0.067     0.0  0.9    0.34"""
+                 non_centered     1   -31        1.5       0              0.0       1.0  0.9    0.32
+                 centered         2   -31        1.4       0.03           0.061     0.0  0.9    0.33"""
 
             @test sprint(show, "text/plain", mc5) == """
                 ModelComparisonResult with PseudoBMA weights
                                rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
-                 non_centered     1   -31        1.4       0              0.0      0.52  0.9    0.32
-                 centered         2   -31        1.4       0.06           0.067    0.48  0.9    0.34"""
+                 non_centered     1   -31        1.5       0              0.0      0.51  0.9    0.32
+                 centered         2   -31        1.4       0.03           0.061    0.49  0.9    0.33"""
 
             @test startswith(sprint(show, "text/html", mc1), "<table")
         end

--- a/test/loo.jl
+++ b/test/loo.jl
@@ -94,13 +94,13 @@ using Test
         @test sprint(show, "text/plain", loo(loglike)) == """
             PSISLOOResult with estimates
              elpd  elpd_mcse    p  p_mcse
-              -31        1.4  0.9    0.34
+              -31        1.4  0.9    0.33
 
             and PSISResult with 500 draws, 4 chains, and 8 parameters
             Pareto shape (k) diagnostic values:
                                 Count      Min. ESS
-             (-Inf, 0.5]  good  6 (75.0%)  135
-              (0.5, 0.7]  okay  2 (25.0%)  421"""
+             (-Inf, 0.5]  good  4 (50.0%)  270
+              (0.5, 0.7]  okay  4 (50.0%)  307"""
     end
     @testset "agrees with R loo" begin
         if r_loo_installed()

--- a/test/waic.jl
+++ b/test/waic.jl
@@ -60,7 +60,7 @@ using Test
         @test sprint(show, "text/plain", waic(loglike)) == """
             WAICResult with estimates
              elpd  elpd_mcse    p  p_mcse
-              -31        1.4  0.9    0.33"""
+              -31        1.4  0.9    0.32"""
     end
     @testset "agrees with R waic" begin
         if r_loo_installed()


### PR DESCRIPTION
ArviZExampleData v0.1.12 re-generated the eight schools data. Since the draws are not identical, the corresponding doctests need to be updated.