### PR TITLE
Improvements to show method precision

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -310,7 +310,8 @@ function _default_prettytables_formatters(data; sigdigits_se=2, sigdigits_defaul
     formatters = []
     col_names = Tables.columnnames(data)
     for (i, k) in enumerate(col_names)
-        for mcse_key in (Symbol("mcse_$k"), Symbol("$(k)_mcse"))
+        for mcse_key in
+            (Symbol("mcse_$k"), Symbol("$(k)_mcse"), Symbol("se_$k"), Symbol("$(k)_se"))
             if haskey(data, mcse_key)
                 push!(
                     formatters,
@@ -322,7 +323,10 @@ function _default_prettytables_formatters(data; sigdigits_se=2, sigdigits_defaul
     end
     mcse_cols = findall(col_names) do k
         s = string(k)
-        return startswith(s, "mcse_") || endswith(s, "_mcse")
+        return startswith(s, "mcse_") ||
+               endswith(s, "_mcse") ||
+               startswith(s, "se_") ||
+               endswith(s, "_se")
     end
     isempty(mcse_cols) || push!(formatters, ft_printf_sigdigits(sigdigits_se, mcse_cols))
     ess_cols = findall(_is_ess_label, col_names)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -193,7 +193,7 @@ end
 # - removes trailing decimal point if no significant digits after decimal point
 function _printf_with_sigdigits(v::Real, sigdigits)
     s = sprint(Printf.format, Printf.Format("%#.$(sigdigits)g"), v)
-    return replace(s, r"\.$" => "")
+    return replace(s, r"\.($|e)" => s"\1")
 end
 
 #

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -289,7 +289,9 @@ function ft_printf_sigdigits_matching_se(
 end
 
 function _prettytables_rhat_formatter(data)
-    cols = findall(x -> x === :rhat, Tables.columnnames(data))
+    cols = findall(
+        x -> (x === :rhat || startswith(string(x), "rhat_")), Tables.columnnames(data)
+    )
     isempty(cols) && return nothing
     return PrettyTables.ft_printf("%.2f", cols)
 end

--- a/test/summarize.jl
+++ b/test/summarize.jl
@@ -142,19 +142,21 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
             data = (
                 est=[111.11, 1.2345e-6, 5.4321e8, Inf, NaN],
                 mcse_est=[0.0012345, 5.432e-5, 2.1234e5, Inf, NaN],
+                se_est=vcat(0.0012345, 5.432e-5, 2.1234e5, Inf, NaN),
                 rhat=vcat(1.009, 1.011, 0.99, Inf, NaN),
+                rhat_bulk=vcat(1.009, 1.011, 0.99, Inf, NaN),
                 ess=vcat(312.45, 23.32, 1011.98, Inf, NaN),
                 ess_bulk=vcat(9.2345, 876.321, 999.99, Inf, NaN),
             )
             stats = SummaryStats(data, parameter_names)
             @test sprint(show, "text/plain", stats) == """
                 SummaryStats
-                              est  mcse_est  rhat   ess  ess_bulk
-                 a    111.110       0.0012   1.01   312         9
-                 bb     1.e-06      5.4e-05  1.01    23       876
-                 ccc    5.432e+08   2.1e+05  0.99  1012      1000
-                 d       Inf         Inf      Inf   Inf       Inf
-                 e       NaN         NaN      NaN   NaN       NaN"""
+                              est  mcse_est   se_est  rhat  rhat_bulk   ess  ess_bulk
+                 a    111.110       0.0012   0.0012   1.01       1.01   312         9
+                 bb     1e-06       5.4e-05  5.4e-05  1.01       1.01    23       876
+                 ccc    5.432e+08   2.1e+05  2.1e+05  0.99       0.99  1012      1000
+                 d       Inf         Inf      Inf      Inf        Inf   Inf       Inf
+                 e       NaN         NaN      NaN      NaN        NaN   NaN       NaN"""
 
             @test startswith(sprint(show, "text/html", stats), "<table")
         end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -133,8 +133,8 @@ using Test
     end
 
     @testset "_printf_with_sigdigits" begin
-        @test PosteriorStats._printf_with_sigdigits(123.456, 1) == "1.e+02"
-        @test PosteriorStats._printf_with_sigdigits(-123.456, 1) == "-1.e+02"
+        @test PosteriorStats._printf_with_sigdigits(123.456, 1) == "1e+02"
+        @test PosteriorStats._printf_with_sigdigits(-123.456, 1) == "-1e+02"
         @test PosteriorStats._printf_with_sigdigits(123.456, 2) == "1.2e+02"
         @test PosteriorStats._printf_with_sigdigits(-123.456, 2) == "-1.2e+02"
         @test PosteriorStats._printf_with_sigdigits(123.456, 3) == "123"
@@ -148,7 +148,7 @@ using Test
         @test PosteriorStats._printf_with_sigdigits(123.456, 7) == "123.4560"
         @test PosteriorStats._printf_with_sigdigits(-123.456, 7) == "-123.4560"
         @test PosteriorStats._printf_with_sigdigits(123.456, 8) == "123.45600"
-        @test PosteriorStats._printf_with_sigdigits(0.00000123456, 1) == "1.e-06"
+        @test PosteriorStats._printf_with_sigdigits(0.00000123456, 1) == "1e-06"
         @test PosteriorStats._printf_with_sigdigits(0.00000123456, 2) == "1.2e-06"
     end
 


### PR DESCRIPTION
This PR makes several improvements to the display precision of numbers in our custom `show` methods:
- Trim trailing decimal in scientific notation
- Recognize prefix `rhat_` as a type of R-hat
- Recognize prefix `se_` and suffix `_se` as a type of standard error (in addition to `mcse`)
