### PR TITLE
Rename `mcse` suffixes to `se` prefixes

### DIFF
--- a/src/compare.jl
+++ b/src/compare.jl
@@ -91,18 +91,18 @@ function compare(
     perm = _sortperm(elpd_results; by=x -> elpd_estimates(x).elpd, rev=true)
     i_elpd_max = first(perm)
     elpd_max_i = elpd_estimates(elpd_results[i_elpd_max]; pointwise=true).elpd
-    elpd_diff_and_mcse = map(elpd_results) do r
+    se_elpd_diff_and = map(elpd_results) do r
         elpd_diff_j = similar(elpd_max_i)
         # workaround for named dimension packages that check dimension names are exact, for
         # cases where dimension names differ
         map!(-, elpd_diff_j, elpd_max_i, elpd_estimates(r; pointwise=true).elpd)
         return _sum_and_se(elpd_diff_j)
     end
-    elpd_diff = map(first, elpd_diff_and_mcse)
-    elpd_diff_mcse = map(last, elpd_diff_and_mcse)
+    elpd_diff = map(first, se_elpd_diff_and)
+    se_elpd_diff = map(last, se_elpd_diff_and)
     rank = _assimilar(elpd_results, (1:length(elpd_results))[perm])
     result = ModelComparisonResult(
-        model_names, rank, elpd_diff, elpd_diff_mcse, weights, elpd_results, weights_method
+        model_names, rank, elpd_diff, se_elpd_diff, weights, elpd_results, weights_method
     )
     sort || return result
     return _permute(result, perm)
@@ -136,8 +136,8 @@ struct ModelComparisonResult{E,N,R,W,ER,M}
     rank::R
     "ELPD of a model subtracted from the largest ELPD of any model"
     elpd_diff::E
-    "Monte Carlo standard error of the ELPD difference"
-    elpd_diff_mcse::E
+    "Standard error of the ELPD difference"
+    se_elpd_diff::E
     "Model weights computed with `weights_method`"
     weight::W
     """`AbstactELPDResult`s for each model, which can be used to access useful stats like
@@ -191,16 +191,14 @@ Tables.istable(::Type{<:ModelComparisonResult}) = true
 Tables.columnaccess(::Type{<:ModelComparisonResult}) = true
 Tables.columns(r::ModelComparisonResult) = r
 function Tables.columnnames(::ModelComparisonResult)
-    return (
-        :name, :rank, :elpd, :elpd_mcse, :elpd_diff, :elpd_diff_mcse, :weight, :p, :p_mcse
-    )
+    return (:name, :rank, :elpd, :se_elpd, :elpd_diff, :se_elpd_diff, :weight, :p, :se_p)
 end
 function Tables.getcolumn(r::ModelComparisonResult, i::Int)
     return Tables.getcolumn(r, Tables.columnnames(r)[i])
 end
 function Tables.getcolumn(r::ModelComparisonResult, nm::Symbol)
     nm ∈ fieldnames(typeof(r)) && return getfield(r, nm)
-    if nm ∈ (:elpd, :elpd_mcse, :p, :p_mcse)
+    if nm ∈ (:elpd, :se_elpd, :p, :se_p)
         return map(e -> getproperty(elpd_estimates(e), nm), r.elpd_result)
     end
     throw(ArgumentError("Unrecognized column name $nm"))

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -49,10 +49,9 @@ julia> mc = compare(models; elpd_method=myloo)
 ┌ Warning: 1 parameters had Pareto shape values 0.7 < k ≤ 1. Resulting importance sampling estimates are likely to be unstable.
 └ @ PSIS ~/.julia/packages/PSIS/...
 ModelComparisonResult with Stacking weights
-               rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p   ⋯
- non_centered     1   -31        1.5       0              0.0       1.0  0.9   ⋯
- centered         2   -31        1.4       0.03           0.061     0.0  0.9   ⋯
-                                                                1 column omitted
+               rank  elpd  se_elpd  elpd_diff  se_elpd_diff  weight    p  se_p ⋯
+ non_centered     1   -31      1.5       0            0.0       1.0  0.9  0.32 ⋯
+ centered         2   -31      1.4       0.03         0.061     0.0  0.9  0.33 ⋯
 julia> mc.weight |> pairs
 pairs(::NamedTuple) with 2 entries:
   :non_centered => 1.0
@@ -67,10 +66,9 @@ julia> elpd_results = mc.elpd_result;
 
 julia> compare(elpd_results; weights_method=BootstrappedPseudoBMA())
 ModelComparisonResult with BootstrappedPseudoBMA weights
-               rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p   ⋯
- non_centered     1   -31        1.5       0              0.0      0.51  0.9   ⋯
- centered         2   -31        1.4       0.03           0.061    0.49  0.9   ⋯
-                                                                1 column omitted
+               rank  elpd  se_elpd  elpd_diff  se_elpd_diff  weight    p  se_p ⋯
+ non_centered     1   -31      1.5       0            0.0      0.51  0.9  0.32 ⋯
+ centered         2   -31      1.4       0.03         0.061    0.49  0.9  0.33 ⋯
 ```
 
 # References

--- a/src/elpdresult.jl
+++ b/src/elpdresult.jl
@@ -17,7 +17,7 @@ function _show_elpd_estimates(
     io::IO, mime::MIME"text/plain", r::AbstractELPDResult; kwargs...
 )
     estimates = elpd_estimates(r)
-    table = map(Base.vect, NamedTuple{(:elpd, :elpd_mcse, :p, :p_mcse)}(estimates))
+    table = map(Base.vect, NamedTuple{(:elpd, :se_elpd, :p, :se_p)}(estimates))
     _show_prettytable(io, mime, table; kwargs...)
     return nothing
 end
@@ -66,7 +66,7 @@ function _lpd_pointwise(log_likelihood, dims)
 end
 
 function _elpd_estimates_from_pointwise(pointwise)
-    elpd, elpd_mcse = _sum_and_se(pointwise.elpd)
-    p, p_mcse = _sum_and_se(pointwise.p)
-    return (; elpd, elpd_mcse, p, p_mcse)
+    elpd, se_elpd = _sum_and_se(pointwise.elpd)
+    p, se_p = _sum_and_se(pointwise.p)
+    return (; elpd, se_elpd, p, se_p)
 end

--- a/src/elpdresult.jl
+++ b/src/elpdresult.jl
@@ -23,7 +23,7 @@ function _show_elpd_estimates(
 end
 
 """
-    $(FUNCTIONNAME)(result::AbstractELPDResult; pointwise=false) -> (; elpd, elpd_mcse, lpd)
+    $(FUNCTIONNAME)(result::AbstractELPDResult; pointwise=false) -> (; elpd, se_elpd, lpd)
 
 Return the (E)LPD estimates from the `result`.
 """

--- a/src/loo.jl
+++ b/src/loo.jl
@@ -63,8 +63,8 @@ julia> reff = ess(log_like; kind=:basic, split_chains=1, relative=true);
 
 julia> loo(log_like; reff)
 PSISLOOResult with estimates
- elpd  elpd_mcse    p  p_mcse
-  -31        1.4  0.9    0.33
+ elpd  se_elpd    p  se_p
+  -31      1.4  0.9  0.33
 
 and PSISResult with 500 draws, 4 chains, and 8 parameters
 Pareto shape (k) diagnostic values:

--- a/src/loo.jl
+++ b/src/loo.jl
@@ -101,13 +101,13 @@ end
 function _loo(log_like, psis_result, dims=(1, 2))
     # compute pointwise estimates
     lpd_i = _maybe_scalar(_lpd_pointwise(log_like, dims))
-    elpd_i, elpd_se_i = map(
+    elpd_i, se_elpd_i = map(
         _maybe_scalar, _elpd_loo_pointwise_and_se(psis_result, log_like, dims)
     )
     p_i = lpd_i - elpd_i
     pointwise = (;
         elpd=elpd_i,
-        elpd_mcse=elpd_se_i,
+        se_elpd=se_elpd_i,
         p=p_i,
         reff=psis_result.reff,
         pareto_shape=psis_result.pareto_shape,
@@ -126,6 +126,6 @@ function _elpd_loo_pointwise_and_se(psis_result::PSIS.PSISResult, log_likelihood
     elpd_i_se = _se_log_mean(log_likelihood, log_weights; dims, log_mean=elpd_i)
     return (
         elpd=_maybe_scalar(dropdims(elpd_i; dims)),
-        elpd_se=_maybe_scalar(dropdims(elpd_i_se; dims) ./ sqrt.(psis_result.reff)),
+        se_elpd=_maybe_scalar(dropdims(elpd_i_se; dims) ./ sqrt.(psis_result.reff)),
     )
 end

--- a/src/model_weights.jl
+++ b/src/model_weights.jl
@@ -105,7 +105,7 @@ function model_weights(method::PseudoBMA, elpd_results)
     elpds = map(elpd_results) do result
         est = elpd_estimates(result)
         method.regularize || return est.elpd
-        return est.elpd - est.elpd_mcse / 2
+        return est.elpd - est.se_elpd / 2
     end
     return _akaike_weights(elpds)
 end

--- a/src/waic.jl
+++ b/src/waic.jl
@@ -46,8 +46,8 @@ julia> log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :s
 
 julia> waic(log_like)
 WAICResult with estimates
- elpd  elpd_mcse    p  p_mcse
-  -31        1.4  0.9    0.32
+ elpd  se_elpd    p  se_p
+  -31      1.4  0.9  0.32
 ```
 
 # References

--- a/test/compare.jl
+++ b/test/compare.jl
@@ -65,21 +65,13 @@ end
             @test Tables.columnaccess(typeof(mc1))
             @test Tables.columns(mc1) == mc1
             @test Tables.columnnames(mc1) == (
-                :name,
-                :rank,
-                :elpd,
-                :elpd_mcse,
-                :elpd_diff,
-                :elpd_diff_mcse,
-                :weight,
-                :p,
-                :p_mcse,
+                :name, :rank, :elpd, :se_elpd, :elpd_diff, :se_elpd_diff, :weight, :p, :se_p
             )
             table = Tables.columntable(mc1)
-            for k in (:name, :rank, :elpd_diff, :elpd_diff_mcse, :weight)
+            for k in (:name, :rank, :elpd_diff, :se_elpd_diff, :weight)
                 @test getproperty(table, k) == collect(getproperty(mc1, k))
             end
-            for k in (:elpd, :elpd_mcse, :p, :p_mcse)
+            for k in (:elpd, :se_elpd, :p, :se_p)
                 @test getproperty(table, k) ==
                     collect(map(x -> getproperty(x.estimates, k), mc1.elpd_result))
             end
@@ -111,15 +103,15 @@ end
             mc5 = compare(eight_schools_loo_results; weights_method=PseudoBMA())
             @test sprint(show, "text/plain", mc1) == """
                 ModelComparisonResult with Stacking weights
-                               rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
-                 non_centered     1   -31        1.5       0              0.0       1.0  0.9    0.32
-                 centered         2   -31        1.4       0.03           0.061     0.0  0.9    0.33"""
+                               rank  elpd  se_elpd  elpd_diff  se_elpd_diff  weight    p  se_p
+                 non_centered     1   -31      1.5       0            0.0       1.0  0.9  0.32
+                 centered         2   -31      1.4       0.03         0.061     0.0  0.9  0.33"""
 
             @test sprint(show, "text/plain", mc5) == """
                 ModelComparisonResult with PseudoBMA weights
-                               rank  elpd  elpd_mcse  elpd_diff  elpd_diff_mcse  weight    p  p_mcse
-                 non_centered     1   -31        1.5       0              0.0      0.51  0.9    0.32
-                 centered         2   -31        1.4       0.03           0.061    0.49  0.9    0.33"""
+                               rank  elpd  se_elpd  elpd_diff  se_elpd_diff  weight    p  se_p
+                 non_centered     1   -31      1.5       0            0.0      0.51  0.9  0.32
+                 centered         2   -31      1.4       0.03         0.061    0.49  0.9  0.33"""
 
             @test startswith(sprint(show, "text/html", mc1), "<table")
         end

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -14,14 +14,14 @@ function loo_r(log_likelihood; reff=nothing)
     estimates = rcopy(R"$(result)$estimates")
     estimates = (
         elpd=estimates[1, 1],
-        elpd_mcse=estimates[1, 2],
+        se_elpd=estimates[1, 2],
         p=estimates[2, 1],
-        p_mcse=estimates[2, 2],
+        se_p=estimates[2, 2],
     )
     pointwise = rcopy(R"$(result)$pointwise")
     pointwise = (
         elpd=pointwise[:, 1],
-        elpd_mcse=pointwise[:, 2],
+        se_elpd=pointwise[:, 2],
         p=pointwise[:, 3],
         reff=reff,
         pareto_shape=pointwise[:, 5],
@@ -36,9 +36,9 @@ function waic_r(log_likelihood)
     estimates = rcopy(R"$(result)$estimates")
     estimates = (
         elpd=estimates[1, 1],
-        elpd_mcse=estimates[1, 2],
+        se_elpd=estimates[1, 2],
         p=estimates[2, 1],
-        p_mcse=estimates[2, 2],
+        se_p=estimates[2, 2],
     )
     pointwise = rcopy(R"$(result)$pointwise")
     pointwise = (elpd=pointwise[:, 1], p=pointwise[:, 2])

--- a/test/loo.jl
+++ b/test/loo.jl
@@ -21,9 +21,8 @@ using Test
             estimates = elpd_estimates(loo_result)
             pointwise = elpd_estimates(loo_result; pointwise=true)
             @testset "return types and values as expected" begin
-                @test estimates isa NamedTuple{(:elpd, :elpd_mcse, :p, :p_mcse),NTuple{4,T}}
-                @test pointwise isa
-                    NamedTuple{(:elpd, :elpd_mcse, :p, :reff, :pareto_shape)}
+                @test estimates isa NamedTuple{(:elpd, :se_elpd, :p, :se_p),NTuple{4,T}}
+                @test pointwise isa NamedTuple{(:elpd, :se_elpd, :p, :reff, :pareto_shape)}
                 if length(sz) == 2
                     @test eltype(pointwise) === T
                 else
@@ -93,8 +92,8 @@ using Test
         # regression test
         @test sprint(show, "text/plain", loo(loglike)) == """
             PSISLOOResult with estimates
-             elpd  elpd_mcse    p  p_mcse
-              -31        1.4  0.9    0.33
+             elpd  se_elpd    p  se_p
+              -31      1.4  0.9  0.33
 
             and PSISResult with 500 draws, 4 chains, and 8 parameters
             Pareto shape (k) diagnostic values:
@@ -112,13 +111,12 @@ using Test
                     result_r = loo_r(log_likelihood; reff)
                     result = loo(log_likelihood; reff)
                     @test result.estimates.elpd ≈ result_r.estimates.elpd
-                    @test result.estimates.elpd_mcse ≈ result_r.estimates.elpd_mcse
+                    @test result.estimates.se_elpd ≈ result_r.estimates.se_elpd
                     @test result.estimates.p ≈ result_r.estimates.p
-                    @test result.estimates.p_mcse ≈ result_r.estimates.p_mcse
+                    @test result.estimates.se_p ≈ result_r.estimates.se_p
                     @test result.pointwise.elpd ≈ result_r.pointwise.elpd
-                    # increased tolerance for elpd_mcse, since we use a different approach
-                    @test result.pointwise.elpd_mcse ≈ result_r.pointwise.elpd_mcse rtol =
-                        0.01
+                    # increased tolerance for se_elpd, since we use a different approach
+                    @test result.pointwise.se_elpd ≈ result_r.pointwise.se_elpd rtol = 0.01
                     @test result.pointwise.p ≈ result_r.pointwise.p
                     @test result.pointwise.reff ≈ result_r.pointwise.reff
                     @test result.pointwise.pareto_shape ≈ result_r.pointwise.pareto_shape

--- a/test/waic.jl
+++ b/test/waic.jl
@@ -21,7 +21,7 @@ using Test
             estimates = elpd_estimates(waic_result)
             pointwise = elpd_estimates(waic_result; pointwise=true)
             @testset "return types and values as expected" begin
-                @test estimates isa NamedTuple{(:elpd, :elpd_mcse, :p, :p_mcse),NTuple{4,T}}
+                @test estimates isa NamedTuple{(:elpd, :se_elpd, :p, :se_p),NTuple{4,T}}
                 @test pointwise isa NamedTuple{(:elpd, :p)}
                 if length(sz) == 2
                     @test eltype(pointwise) === T
@@ -59,8 +59,8 @@ using Test
         # regression test
         @test sprint(show, "text/plain", waic(loglike)) == """
             WAICResult with estimates
-             elpd  elpd_mcse    p  p_mcse
-              -31        1.4  0.9    0.32"""
+             elpd  se_elpd    p  se_p
+              -31      1.4  0.9  0.32"""
     end
     @testset "agrees with R waic" begin
         if r_loo_installed()
@@ -71,9 +71,9 @@ using Test
                 result_r = waic_r(log_likelihood)
                 result = waic(log_likelihood)
                 @test result.estimates.elpd ≈ result_r.estimates.elpd
-                @test result.estimates.elpd_mcse ≈ result_r.estimates.elpd_mcse
+                @test result.estimates.se_elpd ≈ result_r.estimates.se_elpd
                 @test result.estimates.p ≈ result_r.estimates.p
-                @test result.estimates.p_mcse ≈ result_r.estimates.p_mcse
+                @test result.estimates.se_p ≈ result_r.estimates.se_p
                 @test result.pointwise.elpd ≈ result_r.pointwise.elpd
                 @test result.pointwise.p ≈ result_r.pointwise.p
             end


### PR DESCRIPTION
`mcse` is more verbose than is necessary for the standard errors we compute during ELPD calculation. `se` is enough. Also, it makes more sense to use `se` as a prefix instead of a suffix (e.g. one might abbreviate the standard error of the mean in TeX as $$\mathrm{se}_\mathrm{mean}$$. This PR changes `mcse` suffixes to `se` prefixes.