### PR TITLE
Backport Julia lower bound as v1.8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,9 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.8'
+          - 'lts'
           - '1'
-          - '1.6'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PosteriorStats"
 uuid = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ StatsBase = "0.33.7, 0.34"
 TableOperations = "1"
 TableTraits = "1"
 Tables = "1.9"
-julia = "1.6"
+julia = "1.8"
 
 [extras]
 ArviZExampleData = "2f96bb34-afd9-46ae-bcd0-9b2d4372fe3c"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,4 +7,5 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+ArviZExampleData = "0.1.5"
 Documenter = "1"

--- a/src/loo_pit.jl
+++ b/src/loo_pit.jl
@@ -58,9 +58,8 @@ julia> log_like = PermutedDimsArray(idata.log_likelihood.obs, (:draw, :chain, :s
 julia> log_weights = loo(log_like).psis_result.log_weights;
 
 julia> loo_pit(y, y_pred, log_weights)
-╭───────────────────────────────╮
-│ 8-element DimArray{Float64,1} │
-├───────────────────────────────┴──────────────────────────────────────── dims ┐
+┌ 8-element DimArray{Float64, 1} ┐
+├────────────────────────────────┴─────────────────────────────────────── dims ┐
   ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
 └──────────────────────────────────────────────────────────────────────────────┘
  "Choate"            0.943511
@@ -86,9 +85,8 @@ julia> T = y .- median(mu);
 julia> T_pred = y_pred .- mu;
 
 julia> loo_pit(T .^ 2, T_pred .^ 2, log_weights)
-╭───────────────────────────────╮
-│ 8-element DimArray{Float64,1} │
-├───────────────────────────────┴──────────────────────────────────────── dims ┐
+┌ 8-element DimArray{Float64, 1} ┐
+├────────────────────────────────┴─────────────────────────────────────── dims ┐
   ↓ school Categorical{String} [Choate, Deerfield, …, St. Paul's, Mt. Hermon] Unordered
 └──────────────────────────────────────────────────────────────────────────────┘
  "Choate"            0.873577

--- a/src/model_weights.jl
+++ b/src/model_weights.jl
@@ -61,8 +61,8 @@ Now we compute [`BootstrappedPseudoBMA`](@ref) weights for the same models:
 ```jldoctest model_weights; setup = :(using Random; Random.seed!(94))
 julia> model_weights(elpd_results; method=BootstrappedPseudoBMA()) |> pairs
 pairs(::NamedTuple) with 2 entries:
-  :centered     => 0.483723
-  :non_centered => 0.516277
+  :centered     => 0.483727
+  :non_centered => 0.516273
 ```
 """
 function model_weights(elpd_results; method::AbstractModelWeightsMethod=Stacking())

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -194,7 +194,7 @@ julia> x = randn(1000, 4, 3) .+ reshape(0:10:20, 1, 1, :);
 julia> summarize(x, mean, std, :mcse_mean => sem; name="Mean/Std")
 Mean/Std
        mean    std  mcse_mean
- 1   0.0003  0.990      0.016
+ 1   0.0003  0.989      0.016
  2  10.02    0.988      0.016
  3  19.98    0.988      0.016
 ```
@@ -204,7 +204,7 @@ Avoid recomputing the mean by using `mean_and_std`, and provide parameter names:
 julia> summarize(x, (:mean, :std) => mean_and_std, mad; var_names=[:a, :b, :c])
 SummaryStats
          mean    std    mad
- a   0.000305  0.990  0.978
+ a   0.000275  0.989  0.978
  b  10.0       0.988  0.995
  c  20.0       0.988  0.979
 ```
@@ -229,7 +229,7 @@ names:
 julia> summarize(x, default_stats(; prob_interval=0.89)...; var_names=[:a, :b, :c])
 SummaryStats
          mean    std  hdi_5.5%  hdi_94.5%
- a   0.000305  0.990     -1.63       1.52
+ a   0.000275  0.989     -1.63       1.52
  b  10.0       0.988      8.53      11.6
  c  20.0       0.988     18.5       21.6
 ```


### PR DESCRIPTION
This PR backports to v0.2.x setting the Julia lower bound as v1.8