### PR TITLE
Cache R dependencies in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,19 +33,23 @@ jobs:
             os: ubuntu-latest
             arch: x64
             downgrade: true
+
+    env:
+      install_r: ${{ matrix.os == 'ubuntu-latest' }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ env.install_r }}
       - name: Install R loo
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           dependencies: |
             github::stan-dev/loo@v2.8.0
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ env.install_r }}
       - name: Set R lib path for RCall.jl
         run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ env.install_r }}
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
@@ -63,6 +67,7 @@ jobs:
           Pkg.add("Conda");
           Pkg.build("Conda");
         shell: julia --color=yes {0}
+        if: ${{ env.install_r }}
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,17 +37,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
         if: matrix.os == 'ubuntu-latest'
+      - name: Install R loo
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: |
+            github::stan-dev/loo@v2.8.0
+        if: matrix.os == 'ubuntu-latest'
       - name: Set R lib path for RCall.jl
-        if: matrix.os == 'ubuntu-latest'
         run: echo "LD_LIBRARY_PATH=$(R RHOME)/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-      - name: Install R packages
         if: matrix.os == 'ubuntu-latest'
-        run: |
-          install.packages("remotes")
-          remotes::install_github("stan-dev/loo@v2.8.0")
-        shell: Rscript {0}
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}


### PR DESCRIPTION
This PR uses the `r-lib/setup-r-dependencies` action to install R loo for the comparison check. This should allow the dependency to be cached for future workflow runs so that CI runs a bit faster.