### PR TITLE
Refactor summarize

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,6 +9,9 @@ PosteriorStats = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
+[sources]
+PosteriorStats = {path=".."}
+
 [compat]
 Documenter = "1"
 DocumenterCitations = "1.2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,19 +23,22 @@ links = InterLinks(
     ),
 )
 
-makedocs(;
-    modules=[PosteriorStats],
-    repo=Remotes.GitHub("arviz-devs", "PosteriorStats.jl"),
-    sitename="PosteriorStats.jl",
-    format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
-        edit_link="main",
-        assets=[joinpath("assets", "citations.css")],
-    ),
-    pages=["Home" => "index.md", "API" => "api.md", "References" => "references.md"],
-    warnonly=[:doctest, :footnote, :missing_docs],
-    plugins=[bib, links],
-)
+# Increase the terminal width from 80 to 90 chars to avoid column truncation
+withenv("COLUMNS" => 90) do
+    makedocs(;
+        modules=[PosteriorStats],
+        repo=Remotes.GitHub("arviz-devs", "PosteriorStats.jl"),
+        sitename="PosteriorStats.jl",
+        format=Documenter.HTML(;
+            prettyurls=get(ENV, "CI", "false") == "true",
+            edit_link="main",
+            assets=[joinpath("assets", "citations.css")],
+        ),
+        pages=["Home" => "index.md", "API" => "api.md", "References" => "references.md"],
+        warnonly=[:doctest, :footnote, :missing_docs],
+        plugins=[bib, links],
+    )
+end
 
 deploydocs(;
     repo="github.com/arviz-devs/PosteriorStats.jl.git", devbranch="main", push_preview=true

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,10 +8,8 @@ Pages = ["stats.md"]
 
 ```@docs
 SummaryStats
-default_diagnostics
-default_stats
-default_summary_stats
 summarize
+default_summary_stats
 ```
 
 ## Credible intervals

--- a/src/PosteriorStats.jl
+++ b/src/PosteriorStats.jl
@@ -49,7 +49,7 @@ export eti, eti!, hdi, hdi!
 # Others
 export loo_pit, r2_score
 
-const DEFAULT_INTERVAL_PROB = 0.94
+const DEFAULT_CI_PROB = 0.94
 const INFORMATION_CRITERION_SCALES = (deviance=-2, log=1, negative_log=-1)
 
 include("utils.jl")

--- a/src/PosteriorStats.jl
+++ b/src/PosteriorStats.jl
@@ -41,7 +41,7 @@ export ModelComparisonResult, compare
 
 # Summary statistics
 export SummaryStats, summarize
-export default_diagnostics, default_stats, default_summary_stats
+export default_summary_stats
 
 # Credible intervals
 export eti, eti!, hdi, hdi!

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -49,9 +49,9 @@ julia> mc = compare(models; elpd_method=myloo)
 ┌ Warning: 1 parameters had Pareto shape values 0.7 < k ≤ 1. Resulting importance sampling estimates are likely to be unstable.
 └ @ PSIS ~/.julia/packages/PSIS/...
 ModelComparisonResult with Stacking weights
-               rank  elpd  se_elpd  elpd_diff  se_elpd_diff  weight    p  se_p ⋯
- non_centered     1   -31      1.5       0            0.0       1.0  0.9  0.32 ⋯
- centered         2   -31      1.4       0.03         0.061     0.0  0.9  0.33 ⋯
+               rank  elpd  se_elpd  elpd_diff  se_elpd_diff  weight    p  se_p
+ non_centered     1   -31      1.5       0            0.0       1.0  0.9  0.32
+ centered         2   -31      1.4       0.03         0.061     0.0  0.9  0.33
 julia> mc.weight |> pairs
 pairs(::NamedTuple) with 2 entries:
   :non_centered => 1.0
@@ -66,9 +66,9 @@ julia> elpd_results = mc.elpd_result;
 
 julia> compare(elpd_results; weights_method=BootstrappedPseudoBMA())
 ModelComparisonResult with BootstrappedPseudoBMA weights
-               rank  elpd  se_elpd  elpd_diff  se_elpd_diff  weight    p  se_p ⋯
- non_centered     1   -31      1.5       0            0.0      0.51  0.9  0.32 ⋯
- centered         2   -31      1.4       0.03         0.061    0.49  0.9  0.33 ⋯
+               rank  elpd  se_elpd  elpd_diff  se_elpd_diff  weight    p  se_p
+ non_centered     1   -31      1.5       0            0.0      0.51  0.9  0.32
+ centered         2   -31      1.4       0.03         0.061    0.49  0.9  0.33
 ```
 
 # References

--- a/src/eti.jl
+++ b/src/eti.jl
@@ -53,10 +53,7 @@ julia> eti(x)
 ```
 """
 function eti(
-    x::AbstractArray{<:Real};
-    prob::Real=DEFAULT_CI_PROB,
-    sorted::Bool=false,
-    kwargs...,
+    x::AbstractArray{<:Real}; prob::Real=DEFAULT_CI_PROB, sorted::Bool=false, kwargs...
 )
     return eti!(sorted ? x : _copymutable(x); prob, sorted, kwargs...)
 end

--- a/src/eti.jl
+++ b/src/eti.jl
@@ -16,8 +16,7 @@ See also: [`eti!`](@ref), [`hdi`](@ref), [`hdi!`](@ref).
     present
 
 # Keywords
-- `prob`: the probability mass to be contained in the ETI. Default is
-    `$(DEFAULT_INTERVAL_PROB)`.
+- `prob`: the probability mass to be contained in the ETI. Default is `$(DEFAULT_CI_PROB)`.
 - `kwargs`: remaining keywords are passed to [`Statistics.quantile`](@extref).
 
 # Returns
@@ -27,7 +26,7 @@ See also: [`eti!`](@ref), [`hdi`](@ref), [`hdi!`](@ref).
 
 !!! note
     Any default value of `prob` is arbitrary. The default value of
-    `prob=$(DEFAULT_INTERVAL_PROB)` instead of a more common default like `prob=0.95` is
+    `prob=$(DEFAULT_CI_PROB)` instead of a more common default like `prob=0.95` is
     chosen to reminder the user of this arbitrariness.
 
 # Examples
@@ -55,7 +54,7 @@ julia> eti(x)
 """
 function eti(
     x::AbstractArray{<:Real};
-    prob::Real=DEFAULT_INTERVAL_PROB,
+    prob::Real=DEFAULT_CI_PROB,
     sorted::Bool=false,
     kwargs...,
 )
@@ -69,7 +68,7 @@ A version of [`eti`](@ref) that partially sorts `samples` in-place while computi
 
 See also: [`eti`](@ref), [`hdi`](@ref), [`hdi!`](@ref).
 """
-function eti!(x::AbstractArray{<:Real}; prob::Real=DEFAULT_INTERVAL_PROB, kwargs...)
+function eti!(x::AbstractArray{<:Real}; prob::Real=DEFAULT_CI_PROB, kwargs...)
     ndims(x) > 0 ||
         throw(ArgumentError("ETI cannot be computed for a 0-dimensional array."))
     0 < prob < 1 || throw(DomainError(prob, "ETI `prob` must be in the range `(0, 1)`."))

--- a/src/hdi.jl
+++ b/src/hdi.jl
@@ -92,8 +92,7 @@ See also: [`hdi!`](@ref), [`eti`](@ref), [`eti!`](@ref).
     present, a marginal HDI is computed for each.
 
 # Keywords
-- `prob`: the probability mass to be contained in the HDI. Default is
-    `$(DEFAULT_INTERVAL_PROB)`.
+- `prob`: the probability mass to be contained in the HDI. Default is `$(DEFAULT_CI_PROB)`.
 - `sorted=false`: if `true`, the input samples are assumed to be sorted.
 - `method::Symbol`: the method used to estimate the HDI. Available options are:
   - `:unimodal`: Assumes a unimodal distribution (default). Bounds are entries in `samples`.
@@ -116,9 +115,9 @@ See also: [`hdi!`](@ref), [`eti`](@ref), [`eti!`](@ref).
     the shape `(params...,)` is returned, containing marginal HDIs for each parameter.
 
 !!! note
-    Any default value of `prob` is arbitrary. The default value of
-    `prob=$(DEFAULT_INTERVAL_PROB)` instead of a more common default like `prob=0.95` is
-    chosen to remind the user of this arbitrariness.
+    Any default value of `prob` is arbitrary. The default value of `prob=$(DEFAULT_CI_PROB)`
+    instead of a more common default like `prob=0.95` is chosen to remind the user of this
+    arbitrariness.
 
 # Examples
 
@@ -173,7 +172,7 @@ See also: [`hdi`](@ref), [`eti`](@ref), [`eti!`](@ref).
 """
 Base.@constprop :aggressive function hdi!(
     x::AbstractArray{<:Real};
-    prob::Real=DEFAULT_INTERVAL_PROB,
+    prob::Real=DEFAULT_CI_PROB,
     is_discrete::Union{Bool,Nothing}=nothing,
     method::Union{Symbol,HDIEstimationMethod}=UnimodalHDI(),
     sorted::Bool=false,

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -217,11 +217,10 @@ the number of significant digits that will be displayed.
 ```jldoctest summarize
 julia> summarize(x; var_names=[:a, :b, :c])
 SummaryStats
-       mean   std  eti94          ess_tail  ess_bulk  rhat  mcse_mean  mcse_st ⋯
- a   0.0003  0.99  -1.83 .. 1.89      3567      3663  1.00      0.016     0.01 ⋯
- b  10.02    0.99   8.17 .. 11.9      3841      3906  1.00      0.016     0.01 ⋯
- c  19.98    0.99   18.1 .. 21.9      3892      3749  1.00      0.016     0.01 ⋯
-                                                                1 column omitted
+       mean   std  eti94          ess_tail  ess_bulk  rhat  mcse_mean  mcse_std
+ a   0.0003  0.99  -1.83 .. 1.89      3567      3663  1.00      0.016     0.012
+ b  10.02    0.99   8.17 .. 11.9      3841      3906  1.00      0.016     0.011
+ c  19.98    0.99   18.1 .. 21.9      3892      3749  1.00      0.016     0.012
 ```
 
 Compute just the statistics with an 89% HDI on all parameters, and provide the parameter

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -354,8 +354,15 @@ end
 Default diagnostics to be computed with [`summarize`](@ref).
 
 The value of `focus` determines the diagnostics to be returned:
-- [`Statistics.mean`](@extref): `mcse_mean`, `mcse_std`, `ess_tail`, `ess_bulk`, `rhat`
-- [`Statistics.median`](@extref): `mcse_median`, `ess_tail`, `ess_bulk`, `rhat`
+- [`Statistics.mean`](@extref): [`mcse_mean`](@extref MCMCDiagnosticsTools.mcse),
+    [`mcse_std`](@extref MCMCDiagnosticsTools.mcse),
+    [`ess_tail`](@extref MCMCDiagnosticTools.ess),
+    [`ess_bulk`](@extref MCMCDiagnosticTools.ess),
+    [`rhat`](@extref MCMCDiagnosticTools.rhat)
+- [`Statistics.median`](@extref): [`mcse_median`](@extref MCMCDiagnosticsTools.mcse),
+    [`ess_tail`](@extref MCMCDiagnosticTools.ess),
+    [`ess_bulk`](@extref MCMCDiagnosticTools.ess),
+    [`rhat`](@extref MCMCDiagnosticTools.rhat)
 """
 default_diagnostics(; kwargs...) = default_diagnostics(Statistics.mean; kwargs...)
 function default_diagnostics(::typeof(Statistics.mean); kwargs...)

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -217,7 +217,7 @@ the number of significant digits that will be displayed.
 ```jldoctest summarize
 julia> summarize(x; var_names=[:a, :b, :c])
 SummaryStats
-       mean   std  eti_94%        ess_tail  ess_bulk  rhat  mcse_mean  mcse_st ⋯
+       mean   std  eti94          ess_tail  ess_bulk  rhat  mcse_mean  mcse_st ⋯
  a   0.0003  0.99  -1.83 .. 1.89      3567      3663  1.00      0.016     0.01 ⋯
  b  10.02    0.99   8.17 .. 11.9      3841      3906  1.00      0.016     0.01 ⋯
  c  19.98    0.99   18.1 .. 21.9      3892      3749  1.00      0.016     0.01 ⋯
@@ -230,7 +230,7 @@ names:
 ```jldoctest summarize
 julia> summarize(x, default_stats(; ci_prob=0.89)...; var_names=[:a, :b, :c])
 SummaryStats
-         mean    std  eti_89%
+         mean    std  eti89
  a   0.000275  0.989  -1.57 .. 1.59
  b  10.0       0.988   8.47 .. 11.6
  c  20.0       0.988   18.4 .. 21.6
@@ -241,7 +241,7 @@ Compute the summary stats focusing on [`Statistics.median`](@extref):
 ```jldoctest summarize
 julia> summarize(x, default_summary_stats(median)...; var_names=[:a, :b, :c])
 SummaryStats
-    median    mad  eti_94%        ess_tail  ess_median  rhat  mcse_median
+    median    mad  eti94          ess_tail  ess_median  rhat  mcse_median
  a   0.004  0.978  -1.83 .. 1.89      3567        3336  1.00        0.020
  b  10.02   0.995   8.17 .. 11.9      3841        3787  1.00        0.023
  c  19.99   0.979   18.1 .. 21.9      3892        3829  1.00        0.020
@@ -316,9 +316,9 @@ Default statistics to be computed with [`summarize`](@ref).
 
 The value of `focus` determines the statistics to be returned:
 - [`Statistics.mean`](@extref): `mean`, [`std`](@extref `Statistics.std`),
-    `<ci_fun>_<ci_perc>%`
+    `<ci_fun><ci_perc>`
 - [`Statistics.median`](@extref): `median`, [`mad`](@extref `StatsBase.mad`),
-    `<ci_fun>_<ci_perc>%`
+    `<ci_fun><ci_perc>`
 
 The credible interval is computed using the function `ci_fun` with probability `ci_prob`.
 Supported options for `ci_fun` are [`eti`](@ref) and [`hdi`](@ref).
@@ -339,7 +339,7 @@ function default_stats(::typeof(Statistics.median); kwargs...)
 end
 
 function _interval_stat(; ci_fun=eti, ci_prob=DEFAULT_CI_PROB, kwargs...)
-    ci_name = Symbol(_fname(ci_fun), "_", _prob_to_string(ci_prob), "%")
+    ci_name = Symbol(_fname(ci_fun), _prob_to_string(ci_prob))
     return ci_name => (x -> ci_fun(_cskipmissing(x); prob=ci_prob))
 end
 

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -217,10 +217,10 @@ the number of significant digits that will be displayed.
 ```jldoctest summarize
 julia> summarize(x; var_names=[:a, :b, :c])
 SummaryStats
-       mean   std  hdi_94%        mcse_mean  mcse_std  ess_tail  ess_bulk  rha ⋯
- a   0.0003  0.99  -1.92 .. 1.78      0.016     0.012      3567      3663  1.0 ⋯
- b  10.02    0.99   8.17 .. 11.9      0.016     0.011      3841      3906  1.0 ⋯
- c  19.98    0.99   18.1 .. 21.9      0.016     0.012      3892      3749  1.0 ⋯
+       mean   std  eti_94%        ess_tail  ess_bulk  rhat  mcse_mean  mcse_st ⋯
+ a   0.0003  0.99  -1.83 .. 1.89      3567      3663  1.00      0.016     0.01 ⋯
+ b  10.02    0.99   8.17 .. 11.9      3841      3906  1.00      0.016     0.01 ⋯
+ c  19.98    0.99   18.1 .. 21.9      3892      3749  1.00      0.016     0.01 ⋯
                                                                 1 column omitted
 ```
 
@@ -230,10 +230,10 @@ names:
 ```jldoctest summarize
 julia> summarize(x, default_stats(; ci_prob=0.89)...; var_names=[:a, :b, :c])
 SummaryStats
-         mean    std  hdi_89%
- a   0.000275  0.989  -1.63 .. 1.52
- b  10.0       0.988   8.53 .. 11.6
- c  20.0       0.988   18.5 .. 21.6
+         mean    std  eti_89%
+ a   0.000275  0.989  -1.57 .. 1.59
+ b  10.0       0.988   8.47 .. 11.6
+ c  20.0       0.988   18.4 .. 21.6
 ```
 
 Compute the summary stats focusing on [`Statistics.median`](@extref):
@@ -241,10 +241,10 @@ Compute the summary stats focusing on [`Statistics.median`](@extref):
 ```jldoctest summarize
 julia> summarize(x, default_summary_stats(median)...; var_names=[:a, :b, :c])
 SummaryStats
-    median    mad  eti_94%        mcse_median  ess_tail  ess_median  rhat
- a   0.004  0.978  -1.83 .. 1.89        0.020      3567        3336  1.00
- b  10.02   0.995   8.17 .. 11.9        0.023      3841        3787  1.00
- c  19.99   0.979   18.1 .. 21.9        0.020      3892        3829  1.00
+    median    mad  eti_94%        ess_tail  ess_median  rhat  mcse_median
+ a   0.004  0.978  -1.83 .. 1.89      3567        3336  1.00        0.020
+ b  10.02   0.995   8.17 .. 11.9      3841        3787  1.00        0.023
+ c  19.99   0.979   18.1 .. 21.9      3892        3829  1.00        0.020
 ```
 
 Compute multiple [quantiles](@extref `Statistics.quantile`) simultaneously:

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -350,16 +350,16 @@ Default diagnostics to be computed with [`summarize`](@ref).
 
 The value of `focus` determines the diagnostics to be returned:
 - [`Statistics.mean`](@extref):
-    [`ess_tail`](@extref MCMCDiagnosticTools.ess),
-    [`ess_bulk`](@extref MCMCDiagnosticTools.ess),
-    [`rhat`](@extref MCMCDiagnosticTools.rhat),
-    [`mcse_mean`](@extref MCMCDiagnosticsTools.mcse),
-    [`mcse_std`](@extref MCMCDiagnosticsTools.mcse)
+    [`ess_tail`](@extref `MCMCDiagnosticTools.ess`),
+    [`ess_bulk`](@extref `MCMCDiagnosticTools.ess`),
+    [`rhat`](@extref `MCMCDiagnosticTools.rhat`),
+    [`mcse_mean`](@extref `MCMCDiagnosticsTools.mcse`),
+    [`mcse_std`](@extref `MCMCDiagnosticsTools.mcse`)
 - [`Statistics.median`](@extref):
-    [`ess_tail`](@extref MCMCDiagnosticTools.ess),
-    [`ess_bulk`](@extref MCMCDiagnosticTools.ess),
-    [`rhat`](@extref MCMCDiagnosticTools.rhat),
-    [`mcse_median`](@extref MCMCDiagnosticsTools.mcse)
+    [`ess_tail`](@extref `MCMCDiagnosticTools.ess`),
+    [`ess_bulk`](@extref `MCMCDiagnosticTools.ess`),
+    [`rhat`](@extref `MCMCDiagnosticTools.rhat`),
+    [`mcse_median`](@extref `MCMCDiagnosticsTools.mcse`)
 """
 default_diagnostics(; kwargs...) = default_diagnostics(Statistics.mean; kwargs...)
 function default_diagnostics(::typeof(Statistics.mean); kwargs...)

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -313,7 +313,7 @@ function _check_function_names(fnames)
 end
 
 """
-    default_summary_stats(kind::Symbol=:all; kwargs...)
+    default_summary_stats(kind::Symbol=:all; [ci_fun,] [ci_prob,] kwargs...)
 
 Return a collection of stats functions based on the named preset `kind`.
 
@@ -322,16 +322,19 @@ These functions are then passed to [`summarize`](@ref).
 # Arguments
 
 $(_DEFAULT_SUMMARY_STATS_KIND_DOCSTRING)
+- `kwargs`: additional keyword arguments are forwarded to [`mcse`](@ref), [`ess`](@ref), or
+    [`rhat`](@ref) if applicable, otherwise ignored.
 
 # Keywords
 
 $(_DEFAULT_SUMMARY_STATS_CI_DOCSTRING)
+- `kwargs`: additional keyword arguments passed to the default summary statistics functions.
 """
 function default_summary_stats(kind::Symbol=:all; kwargs...)
     return default_summary_stats(Val(kind); kwargs...)
 end
 function default_summary_stats(::Val{:all}; kwargs...)
-    return (_default_stats(kwargs...)..., _default_diagnostics(kwargs...)...)
+    return (_default_stats(; kwargs...)..., _default_diagnostics(; kwargs...)...)
 end
 default_summary_stats(::Val{:stats}; kwargs...) = _default_stats(; kwargs...)
 default_summary_stats(::Val{:diagnostics}; kwargs...) = _default_diagnostics(; kwargs...)
@@ -375,19 +378,29 @@ end
 
 _default_diagnostics(; kwargs...) = _default_diagnostics(Statistics.mean; kwargs...)
 function _default_diagnostics(::typeof(Statistics.mean); kwargs...)
+    ess_kwargs = filter(∈((:maxlag, :autocov_method, :split_chains)) ∘ first, kwargs)
+    ess_tail_kwargs = (ess_kwargs..., filter(k -> first(k) === :tail_prob, kwargs)...)
+    mcse_kwargs = ess_kwargs
     return (
-        :ess_tail => FixKeywords(MCMCDiagnosticTools.ess; kind=:tail),
-        (:ess_bulk, :rhat) => MCMCDiagnosticTools.ess_rhat,
-        :mcse_mean => MCMCDiagnosticTools.mcse,
-        :mcse_std => FixKeywords(MCMCDiagnosticTools.mcse; kind=Statistics.std),
+        :ess_tail => FixKeywords(MCMCDiagnosticTools.ess; kind=:tail, ess_tail_kwargs...),
+        (:ess_bulk, :rhat) => FixKeywords(MCMCDiagnosticTools.ess_rhat; ess_kwargs...),
+        :mcse_mean => FixKeywords(MCMCDiagnosticTools.mcse; mcse_kwargs...),
+        :mcse_std =>
+            FixKeywords(MCMCDiagnosticTools.mcse; kind=Statistics.std, mcse_kwargs...),
     )
 end
 function _default_diagnostics(::typeof(Statistics.median); kwargs...)
+    ess_kwargs = filter(∈((:maxlag, :autocov_method, :split_chains)) ∘ first, kwargs)
+    ess_tail_kwargs = (ess_kwargs..., filter(k -> first(k) === :tail_prob, kwargs)...)
+    mcse_kwargs = ess_kwargs
+    rhat_kwargs = filter(x -> first(x) === :split_chains, kwargs)
     return (
-        :ess_median => FixKeywords(MCMCDiagnosticTools.ess; kind=Statistics.median),
-        :ess_tail => FixKeywords(MCMCDiagnosticTools.ess; kind=:tail),
-        MCMCDiagnosticTools.rhat,
-        :mcse_median => FixKeywords(MCMCDiagnosticTools.mcse; kind=Statistics.median),
+        :ess_median =>
+            FixKeywords(MCMCDiagnosticTools.ess; kind=Statistics.median, ess_kwargs...),
+        :ess_tail => FixKeywords(MCMCDiagnosticTools.ess; kind=:tail, ess_tail_kwargs...),
+        :rhat => FixKeywords(MCMCDiagnosticTools.rhat; rhat_kwargs...),
+        :mcse_median =>
+            FixKeywords(MCMCDiagnosticTools.mcse; kind=Statistics.median, mcse_kwargs...),
     )
 end
 
@@ -433,3 +446,7 @@ _map_paramslices(f::typeof(MCMCDiagnosticTools.rhat), x) = f(x)
 _map_paramslices(f::typeof(MCMCDiagnosticTools.mcse), x) = f(x)
 _map_paramslices(f::FixKeywords{typeof(MCMCDiagnosticTools.ess)}, x) = f.f(x; f.kwargs...)
 _map_paramslices(f::FixKeywords{typeof(MCMCDiagnosticTools.mcse)}, x) = f.f(x; f.kwargs...)
+function _map_paramslices(f::FixKeywords{typeof(MCMCDiagnosticTools.ess_rhat)}, x)
+    f.f(x; f.kwargs...)
+end
+_map_paramslices(f::FixKeywords{typeof(MCMCDiagnosticTools.rhat)}, x) = f.f(x; f.kwargs...)

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -352,13 +352,13 @@ The value of `focus` determines the diagnostics to be returned:
     [`ess_tail`](@extref `MCMCDiagnosticTools.ess`),
     [`ess_bulk`](@extref `MCMCDiagnosticTools.ess`),
     [`rhat`](@extref `MCMCDiagnosticTools.rhat`),
-    [`mcse_mean`](@extref `MCMCDiagnosticsTools.mcse`),
-    [`mcse_std`](@extref `MCMCDiagnosticsTools.mcse`)
+    [`mcse_mean`](@extref `MCMCDiagnosticTools.mcse`),
+    [`mcse_std`](@extref `MCMCDiagnosticTools.mcse`)
 - [`Statistics.median`](@extref):
     [`ess_tail`](@extref `MCMCDiagnosticTools.ess`),
     [`ess_bulk`](@extref `MCMCDiagnosticTools.ess`),
     [`rhat`](@extref `MCMCDiagnosticTools.rhat`),
-    [`mcse_median`](@extref `MCMCDiagnosticsTools.mcse`)
+    [`mcse_median`](@extref `MCMCDiagnosticTools.mcse`)
 """
 default_diagnostics(; kwargs...) = default_diagnostics(Statistics.mean; kwargs...)
 function default_diagnostics(::typeof(Statistics.mean); kwargs...)

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -325,17 +325,12 @@ Supported options for `ci_fun` are [`eti`](@ref) and [`hdi`](@ref).
 """
 function default_stats end
 default_stats(; kwargs...) = default_stats(Statistics.mean; kwargs...)
-function default_stats(
-    ::typeof(Statistics.mean); kwargs...
-)
+function default_stats(::typeof(Statistics.mean); kwargs...)
     return (
-        (:mean, :std) => StatsBase.mean_and_std ∘ _skipmissing,
-        _interval_stat(; kwargs...),
+        (:mean, :std) => StatsBase.mean_and_std ∘ _skipmissing, _interval_stat(; kwargs...)
     )
 end
-function default_stats(
-    ::typeof(Statistics.median); kwargs...
-)
+function default_stats(::typeof(Statistics.median); kwargs...)
     return (
         :median => Statistics.median ∘ _skipmissing,
         :mad => StatsBase.mad ∘ _skipmissing,

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -354,31 +354,33 @@ end
 Default diagnostics to be computed with [`summarize`](@ref).
 
 The value of `focus` determines the diagnostics to be returned:
-- [`Statistics.mean`](@extref): [`mcse_mean`](@extref MCMCDiagnosticsTools.mcse),
-    [`mcse_std`](@extref MCMCDiagnosticsTools.mcse),
+- [`Statistics.mean`](@extref):
     [`ess_tail`](@extref MCMCDiagnosticTools.ess),
     [`ess_bulk`](@extref MCMCDiagnosticTools.ess),
-    [`rhat`](@extref MCMCDiagnosticTools.rhat)
-- [`Statistics.median`](@extref): [`mcse_median`](@extref MCMCDiagnosticsTools.mcse),
+    [`rhat`](@extref MCMCDiagnosticTools.rhat),
+    [`mcse_mean`](@extref MCMCDiagnosticsTools.mcse),
+    [`mcse_std`](@extref MCMCDiagnosticsTools.mcse)
+- [`Statistics.median`](@extref):
     [`ess_tail`](@extref MCMCDiagnosticTools.ess),
     [`ess_bulk`](@extref MCMCDiagnosticTools.ess),
-    [`rhat`](@extref MCMCDiagnosticTools.rhat)
+    [`rhat`](@extref MCMCDiagnosticTools.rhat),
+    [`mcse_median`](@extref MCMCDiagnosticsTools.mcse)
 """
 default_diagnostics(; kwargs...) = default_diagnostics(Statistics.mean; kwargs...)
 function default_diagnostics(::typeof(Statistics.mean); kwargs...)
     return (
-        :mcse_mean => MCMCDiagnosticTools.mcse,
-        :mcse_std => _mcse_std,
         :ess_tail => _ess_tail,
         (:ess_bulk, :rhat) => MCMCDiagnosticTools.ess_rhat,
+        :mcse_mean => MCMCDiagnosticTools.mcse,
+        :mcse_std => _mcse_std,
     )
 end
 function default_diagnostics(::typeof(Statistics.median); kwargs...)
     return (
-        :mcse_median => _mcse_median,
         :ess_tail => _ess_tail,
         :ess_median => _ess_median,
         MCMCDiagnosticTools.rhat,
+        :mcse_median => _mcse_median,
     )
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,16 @@
+"""
+    FixKeywords(f; kwargs...)
+    FixKeywords(f, kwargs)
+
+A type representing the function `(xs...) -> f(xs...; kwargs...)`.
+"""
+struct FixKeywords{F,KW}
+    f::F
+    kwargs::KW
+end
+FixKeywords(f; kwargs...) = FixKeywords(f, NamedTuple(kwargs))
+(f::FixKeywords)(args...) = f.f(args...; f.kwargs...)
+
 function _check_log_likelihood(x)
     if any(!isfinite, x)
         @warn "All log likelihood values must be finite, but some are not."

--- a/test/summarize.jl
+++ b/test/summarize.jl
@@ -220,7 +220,7 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                             x,
                             mean,
                             std,
-                            Symbol("eti_94%") => eti,
+                            Symbol("eti94") => eti,
                             :ess_tail => (x -> ess(x; kind=:tail)),
                             :ess_bulk => (x -> ess(x; kind=:bulk)),
                             rhat,
@@ -240,8 +240,7 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                             x,
                             median,
                             mad,
-                            Symbol("hdi_90%") =>
-                                (x -> PosteriorStats.hdi(vec(x); prob=0.9)),
+                            Symbol("hdi90") => (x -> PosteriorStats.hdi(vec(x); prob=0.9)),
                             :ess_tail => (x -> ess(x; kind=:tail)),
                             :ess_median => (x -> ess(x; kind=median)),
                             rhat,
@@ -270,7 +269,7 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                     map(
                         _isapprox,
                         summarize(x, default_stats()...),
-                        summarize(x, mean, std, Symbol("eti_94%") => eti),
+                        summarize(x, mean, std, Symbol("eti94") => eti),
                     ),
                 )
 
@@ -279,9 +278,9 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                 stats4 = summarize(x2, default_summary_stats()...)
                 @test stats4[:mean] ≈ [mean(skipmissing(x2[:, :, 1])); stats1[:mean][2:end]]
                 @test stats4[:std] ≈ [std(skipmissing(x2[:, :, 1])); stats1[:std][2:end]]
-                @test stats4[Symbol("eti_94%")] == [
+                @test stats4[Symbol("eti94")] == [
                     eti(collect(skipmissing(x2[:, :, 1])))
-                    stats1[Symbol("eti_94%")][2:end]
+                    stats1[Symbol("eti94")][2:end]
                 ]
                 for k in (:ess_tail, :ess_bulk, :rhat, :mcse_mean, :mcse_std)
                     @test stats4[k][1] === missing
@@ -294,9 +293,9 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                 @test stats5[:median] ≈
                     [median(skipmissing(x2[:, :, 1])); stats2[:median][2:end]]
                 @test stats5[:mad] ≈ [mad(skipmissing(x2[:, :, 1])); stats2[:mad][2:end]]
-                @test stats5[Symbol("hdi_90%")] == [
+                @test stats5[Symbol("hdi90")] == [
                     PosteriorStats.hdi(collect(skipmissing(x2[:, :, 1])); prob=0.9)
-                    stats2[Symbol("hdi_90%")][2:end]
+                    stats2[Symbol("hdi90")][2:end]
                 ]
                 for k in (:ess_tail, :ess_median, :rhat, :mcse_median)
                     @test stats5[k][1] === missing

--- a/test/summarize.jl
+++ b/test/summarize.jl
@@ -229,7 +229,9 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                         ),
                     ),
                 )
-                stats2 = summarize(x, default_summary_stats(median; ci_fun=hdi, ci_prob=0.9)...)
+                stats2 = summarize(
+                    x, default_summary_stats(median; ci_fun=hdi, ci_prob=0.9)...
+                )
                 @test all(
                     map(
                         _isapprox,
@@ -286,7 +288,9 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                     @test stats4[k][2:end] ≈ stats1[k][2:end]
                 end
 
-                stats5 = summarize(x2, default_summary_stats(median; ci_fun=hdi, ci_prob=0.9)...)
+                stats5 = summarize(
+                    x2, default_summary_stats(median; ci_fun=hdi, ci_prob=0.9)...
+                )
                 @test stats5[:median] ≈
                     [median(skipmissing(x2[:, :, 1])); stats2[:median][2:end]]
                 @test stats5[:mad] ≈ [mad(skipmissing(x2[:, :, 1])); stats2[:mad][2:end]]

--- a/test/summarize.jl
+++ b/test/summarize.jl
@@ -229,6 +229,16 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                         if kind ∈ [:all_median, :diagnostics_median]
                             @test haskey(stats, :ess_median)
                         end
+
+                        kind ∈ [:stats, :stats_median] && continue
+                        @testset "check that keywords are forwarded" begin
+                            stats2 = summarize(x; kind, split_chains=8)
+                            @testset for k in [:rhat, :ess_tail, :mcse_mean, :mcse_std]
+                                if k ∈ keys(stats)
+                                    @test stats[k] != stats2[k]
+                                end
+                            end
+                        end
                     end
                 end
 

--- a/test/summarize.jl
+++ b/test/summarize.jl
@@ -210,6 +210,28 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
         @testset "default stats function sets" begin
             @testset "array inputs" begin
                 x = randn(1_000, 4, 3)
+
+                @testset "all supported kinds accepted" begin
+                    @testset for kind in [
+                        :all,
+                        :stats,
+                        :diagnostics,
+                        :all_median,
+                        :stats_median,
+                        :diagnostics_median,
+                    ]
+                        stats = summarize(x; kind)
+                        @test stats isa SummaryStats
+                        @test stats.name == "SummaryStats"
+                        kind ∈ [:all, :stats] && @test haskey(stats, :mean)
+                        kind ∈ [:all, :diagnostics] && @test haskey(stats, :ess_bulk)
+                        kind ∈ [:all_median, :stats_median] && @test haskey(stats, :median)
+                        if kind ∈ [:all_median, :diagnostics_median]
+                            @test haskey(stats, :ess_median)
+                        end
+                    end
+                end
+
                 # not completely type-inferrable due to CI
                 stats1 = summarize(x, default_summary_stats()...)
                 @test all(
@@ -229,9 +251,7 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                         ),
                     ),
                 )
-                stats2 = summarize(
-                    x, default_summary_stats(median; ci_fun=hdi, ci_prob=0.9)...
-                )
+                stats2 = summarize(x; kind=:all_median, ci_fun=hdi, ci_prob=0.9)
                 @test all(
                     map(
                         _isapprox,
@@ -241,14 +261,14 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                             median,
                             mad,
                             Symbol("hdi90") => (x -> PosteriorStats.hdi(vec(x); prob=0.9)),
-                            :ess_tail => (x -> ess(x; kind=:tail)),
                             :ess_median => (x -> ess(x; kind=median)),
+                            :ess_tail => (x -> ess(x; kind=:tail)),
                             rhat,
                             :mcse_median => (x -> mcse(x; kind=median)),
                         ),
                     ),
                 )
-                _compute_diagnostics(x) = summarize(x, default_diagnostics()...)
+                _compute_diagnostics(x) = summarize(x; kind=:diagnostics)
                 stats3 = @inferred _compute_diagnostics(x)
                 @test all(
                     map(
@@ -268,14 +288,14 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                 @test all(
                     map(
                         _isapprox,
-                        summarize(x, default_stats()...),
+                        summarize(x; kind=:stats),
                         summarize(x, mean, std, Symbol("eti94") => eti),
                     ),
                 )
 
                 x2 = convert(Array{Union{Float64,Missing}}, x)
                 x2[1, 1, 1] = missing
-                stats4 = summarize(x2, default_summary_stats()...)
+                stats4 = summarize(x2)
                 @test stats4[:mean] ≈ [mean(skipmissing(x2[:, :, 1])); stats1[:mean][2:end]]
                 @test stats4[:std] ≈ [std(skipmissing(x2[:, :, 1])); stats1[:std][2:end]]
                 @test stats4[Symbol("eti94")] == [
@@ -287,9 +307,7 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
                     @test stats4[k][2:end] ≈ stats1[k][2:end]
                 end
 
-                stats5 = summarize(
-                    x2, default_summary_stats(median; ci_fun=hdi, ci_prob=0.9)...
-                )
+                stats5 = summarize(x2; kind=:all_median, ci_fun=hdi, ci_prob=0.9)
                 @test stats5[:median] ≈
                     [median(skipmissing(x2[:, :, 1])); stats2[:median][2:end]]
                 @test stats5[:mad] ≈ [mad(skipmissing(x2[:, :, 1])); stats2[:mad][2:end]]
@@ -306,15 +324,12 @@ _mean_and_std(x) = (mean=mean(x), std=std(x))
             @testset "custom inputs" begin
                 x = randn(1_000, 4, 3)
                 sample = SampleWrapper(x, ["a", "b", "c"])
-                function _compute_diagnostics(x)
-                    return summarize(x, default_diagnostics()...; name="foo")
-                end
+                _compute_diagnostics(x) = summarize(x; kind=:diagnostics, name="foo")
                 stats1 = @inferred _compute_diagnostics(sample)
                 @test stats1 isa SummaryStats
                 @test stats1.name == "foo"
-                @test stats1 == summarize(
-                    x, default_diagnostics()...; name="foo", var_names=["a", "b", "c"]
-                )
+                @test stats1 ==
+                    summarize(x; kind=:diagnostics, name="foo", var_names=["a", "b", "c"])
 
                 stats2 = summarize(sample)
                 @test stats2.name == "SummaryStats"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -6,6 +6,16 @@ using Statistics
 using Test
 
 @testset "utils" begin
+    @testset "FixKeywords" begin
+        x = randn(10, 5)
+        f = @inferred PosteriorStats.FixKeywords(sum; dims=1)
+        @test f.f === sum
+        @test f.kwargs === (dims=1,)
+        @test @inferred(f(x)) == sum(x; dims=1)
+        f = @inferred PosteriorStats.FixKeywords(sum; dims=2)
+        @test f(x) == sum(x; dims=2)
+    end
+
     @testset "_assimilar" begin
         @testset for x in ([8, 2, 5], (8, 2, 5), (; a=8, b=2, c=5))
             @test @inferred(PosteriorStats._assimilar((x=1.0, y=2.0, z=3.0), x)) ==


### PR DESCRIPTION
This PR adds a number of features to `summarize` to bring it more in-line with [`arviz_stats.summary`](https://arviz-stats.readthedocs.io/en/latest/api/generated/arviz_stats.summary.html) and improve the user API. API changes include:
- Change default CI to `eti`
- Reorder columns
- Make CI column name more compact (e.g. `eti94` instead of `eti_94%`)
- `prob_interval` keyword renamed to `ci_prob`
- Add `kind` keyword with presets `all`, `stats`, `diagnostics`, `all_median`, `stats_median`, and `diagnostics_median`. (`mc_diagnostics` currently omitted since we don't have all implemented)
- Remove `default_stats` and `default_diagnostics` in favor of users specifying `kind` 
- Forward relevant keywords passed to `summarize` to `default_summary_stats` and ultimately to `mcse`, `ess`, and `rhat`. e.g. it's not straightforward to change the `autocov_method`, `split_chains`, or `tail_prob`

Additional minor changes include:
- Docs are built with terminal width 90 to avoid truncation of columns
- `summarize` docstring is simplified, along with an extended help that documents how it should be extended.