### PR TITLE
Remove SummaryStats's fields, type parameters, and indexing interface from the public API

### DIFF
--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -23,8 +23,11 @@ A container for a column table of values computed by [`summarize`](@ref).
 This object implements the Tables and TableTraits column table interfaces. It has a custom
 `show` method.
 
-`SummaryStats` behaves like an `OrderedDict` of columns, where the columns can be accessed
-using either `Symbol`s or a 1-based integer index.
+!!! note
+    `SummaryStats` behaves like an `OrderedDict` of columns, where the columns can be
+    accessed using either `Symbol`s or a 1-based integer index. However, this interface
+    is not part of the public API and may change in the future. We recommend using it
+    only interactively.
 
 $(TYPEDFIELDS)
 

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -16,7 +16,7 @@ const _DEFAULT_SUMMARY_STATS_CI_DOCSTRING = """
 """
 
 """
-$(TYPEDEF)
+    struct SummaryStats
 
 A container for a column table of values computed by [`summarize`](@ref).
 
@@ -29,22 +29,25 @@ This object implements the Tables and TableTraits column table interfaces. It ha
     is not part of the public API and may change in the future. We recommend using it
     only interactively.
 
-$(TYPEDFIELDS)
+# Constructors
 
-    SummaryStats([name::String,] data[, parameter_names])
-    SummaryStats(data[, parameter_names]; name::String="SummaryStats")
+    SummaryStats([name,] data[, parameter_names])
+    SummaryStats(data[, parameter_names]; name="SummaryStats")
 
 Construct a `SummaryStats` from tabular `data` with optional stats `name` and `param_names`.
 
-`data` must not contain a column `:parameter`, as this is reserved for the parameter names,
-which are always in the first column.
+## Arguments
+
+$(TYPEDFIELDS)
 """
 struct SummaryStats{D,V<:AbstractVector}
     "The name of the collection of summary statistics, used as the table title in display."
     name::String
-    """The summary statistics for each parameter. It must implement the Tables interface."""
+    """The summary statistics for each parameter. It must implement the Tables interface and
+    may not contain a column `:parameter`, as this is reserved for the parameter names,
+    which are always in the first column."""
     data::D
-    "Names of the parameters"
+    "Names of the parameters."
     parameter_names::V
     function SummaryStats(name::String, data, parameter_names::V) where {V}
         coltable = Tables.columns(data)


### PR DESCRIPTION
This PR removes SummaryStats's fields, type parameters, and `OrderedDict`-like indexing behavior from the public API and advises in the docstring only interactive use. We need to think carefully about what API users will find most useful here, and this allows us to change the API or internal fields in the future without making a breaking release.