### PR TITLE
Update r2_score

### DIFF
--- a/src/r2_score.jl
+++ b/src/r2_score.jl
@@ -3,6 +3,14 @@
 
 ``R²`` for linear Bayesian regression models.[Gelman2019](@citep)
 
+The ``R²``, or coefficient of determination, is defined as the proportion of variance in the
+data that is explained by the model. For each draw, it is computed as the variance of the
+predicted values divided by the variance of the predicted values plus the variance of the
+residuals.
+
+The distribution of the ``R²`` scores can then be summarized using the mean and a credible
+interval (CI).
+
 # Arguments
 
   - `y_true`: Observed data of length `noutputs`

--- a/test/r2_score.jl
+++ b/test/r2_score.jl
@@ -3,7 +3,7 @@ using PosteriorStats
 using Statistics
 using Test
 
-@testset "r2_score/r2_sample" begin
+@testset "r2_score" begin
     @testset "basic" begin
         n = 100
         @testset for T in (Float32, Float64),
@@ -17,11 +17,18 @@ using Test
             x_reshape = length(sz) == 1 ? x' : reshape(x, 1, 1, :)
             y_pred = slope .* x_reshape .+ intercept .+ randn(T, sz..., n) .* σ
 
-            r2_val = @inferred r2_score(y, y_pred)
-            @test r2_val isa NamedTuple{(:r2, :r2_std),NTuple{2,T}}
-            r2_draws = @inferred PosteriorStats.r2_samples(y, y_pred)
-            @test r2_val.r2 ≈ mean(r2_draws)
-            @test r2_val.r2_std ≈ std(r2_draws; corrected=false)
+            r2_val = @inferred r2_score(y, y_pred; ci_prob=T(0.89))
+            @test r2_val isa @NamedTuple{r2::T, eti::ClosedInterval{T}}
+            r2_draws = @inferred PosteriorStats._r2_samples(y, y_pred)
+            @test r2_val.r2 == mean(r2_draws)
+            @test r2_val.eti == eti(r2_draws; prob=T(0.89))
+
+            r2_val2 = r2_score(y, y_pred; ci_fun=hdi, ci_prob=T(0.95))
+            @test r2_val2 isa @NamedTuple{r2::T, hdi::ClosedInterval{T}}
+            @test r2_val2.hdi == hdi(r2_draws; prob=0.95)
+
+            r2_draws2 = PosteriorStats.r2_score(y, y_pred; summary=false)
+            @test r2_draws2 == r2_draws
 
             # check rough consistency with GLM
             res = lm(@formula(y ~ 1 + x), (; x=Float64.(x), y=Float64.(y)))

--- a/test/r2_score.jl
+++ b/test/r2_score.jl
@@ -23,9 +23,12 @@ using Test
             @test r2_val.r2 == mean(r2_draws)
             @test r2_val.eti == eti(r2_draws; prob=T(0.89))
 
-            r2_val2 = r2_score(y, y_pred; ci_fun=hdi, ci_prob=T(0.95))
+            r2_val2 = r2_score(
+                y, y_pred; point_estimate=median, ci_fun=hdi, ci_prob=T(0.95)
+            )
             @test r2_val2 isa @NamedTuple{r2::T, hdi::ClosedInterval{T}}
-            @test r2_val2.hdi == hdi(r2_draws; prob=0.95)
+            @test r2_val2.r2 == median(r2_draws)
+            @test r2_val2.hdi == hdi(r2_draws; prob=T(0.95))
 
             r2_draws2 = PosteriorStats.r2_score(y, y_pred; summary=false)
             @test r2_draws2 == r2_draws


### PR DESCRIPTION
Updates `r2_score` with keywords `summary`, `point_estimate`, `ci_fun`, `ci_prob`. By default, `r2_score` now returns a summary like the previous behaviour but where the std is replaced with a CI. If `summary=false`, the per-draw R-squared values are returned. Relates #48 .