### PR TITLE
Avoid unnecessarily eltype promotion for CIs

### DIFF
--- a/src/PosteriorStats.jl
+++ b/src/PosteriorStats.jl
@@ -48,7 +48,7 @@ export eti, eti!, hdi, hdi!
 # Others
 export loo_pit, r2_score
 
-const DEFAULT_CI_PROB = 0.89
+const DEFAULT_CI_PROB = 0.89f0
 const INFORMATION_CRITERION_SCALES = (deviance=-2, log=1, negative_log=-1)
 
 include("utils.jl")

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -303,7 +303,7 @@ function default_summary_stats(kind::Symbol=:all; kwargs...)
     return default_summary_stats(Val(kind); kwargs...)
 end
 function default_summary_stats(::Val{:all}; kwargs...)
-    return (_default_stats(kwargs...)..., _default_diagnostics(kwargs...)...)
+    return (_default_stats(; kwargs...)..., _default_diagnostics(; kwargs...)...)
 end
 default_summary_stats(::Val{:stats}; kwargs...) = _default_stats(; kwargs...)
 default_summary_stats(::Val{:diagnostics}; kwargs...) = _default_diagnostics(; kwargs...)

--- a/test/hdi.jl
+++ b/test/hdi.jl
@@ -163,6 +163,14 @@ end
     @testset "Method-specific behavior" begin
         @testset "UnimodalHDI" begin
             method = PosteriorStats.UnimodalHDI()
+
+            @testset "eltype not promoted" begin
+                @testset for T in (Float32, Float64, Int)
+                    x = T <: Integer ? rand(T(1):T(30), 100) : randn(T, 100)
+                    interval = hdi(x; method, prob=0.9)
+                    @test eltype(interval) === T
+                end
+            end
         end
 
         @testset "MultimodalHDI" begin


### PR DESCRIPTION
This PR adds more tests for the returned eltype of CI methods `eti` and `hdi` and makes sure in the case of `eti` that the eltype isn't promoted unnecessarily. In particular, if the array is `Float32` and the default probability is used, then the returned interval has a `Float32` eltype.

It also fixes a bug in keyword argument forwarding in `summarize`.