### PR TITLE
docs: fix shape of expected array in LOO docstring

### DIFF
--- a/src/loo.jl
+++ b/src/loo.jl
@@ -36,7 +36,7 @@ Compute the Pareto-smoothed importance sampling leave-one-out cross-validation (
 [Vehtari2017, LOOFAQ](@cite)
 
 `log_likelihood` must be an array of log-likelihood values with shape
-`(chains, draws[, params...])`.
+`(draws, chains[, params...])`.
 
 # Keywords
 


### PR DESCRIPTION
The docstring has the dimensions in the wrong way round. (PSIS is correct :) https://julia.arviz.org/PSIS/stable/api/#PSIS.psis)

Given that this is just a docs change I'm not sure if you'd like a patch bump, happy to do so if desired.