### PR TITLE
docs: Fix failing doctest for almost-zero model weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Documentation
 
 - Fix shape of expected array in LOO docs ([#96](https://github.com/arviz-devs/PosteriorStats.jl/pull/96))
+- Fix failing doctest for almost-zero model weights ([#97](https://github.com/arviz-devs/PosteriorStats.jl/pull/97))
 
 ## v0.4.8 (2026-03-07)
 

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -27,7 +27,7 @@ The ELPD is estimated by Pareto smoothed importance sampling leave-one-out cross
 
 Compare the centered and non centered models of the eight school problem:
 
-```jldoctest compare; filter = [r"└.*", r"(\\d+\\.\\d{3})\\d*" => s"\\1"]
+```jldoctest compare; filter = [r"└.*", r"(\\d+\\.\\d{3})\\d*" => s"\\1", r"(centered\\s*=\\s*)(?:0\\.0|[-+]?\\d+(?:\\.\\d+)?e-(?:1[5-9]|[2-9]\\d|1\\d{2,}))" => s"\\g<1>0.0"]
 julia> using ArviZExampleData
 
 julia> models = (

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -42,10 +42,8 @@ ModelComparisonResult with Stacking weights
                rank  elpd  se_elpd  elpd_diff  se_elpd_diff  weight    p  se_p
  non_centered     1   -31      1.5       0            0.0       1.0  0.9  0.32
  centered         2   -31      1.4       0.03         0.061     0.0  0.9  0.33
-julia> mc.weight |> pairs
-pairs(::NamedTuple) with 2 entries:
-  :non_centered => 1.0
-  :centered     => 3.50546e-31
+julia> mc.weight
+(non_centered = 1.0, centered = 0.0)
 ```
 
 Compare the same models from pre-computed PSIS-LOO results and computing

--- a/src/model_weights.jl
+++ b/src/model_weights.jl
@@ -44,19 +44,15 @@ julia> elpd_results = map(models) do idata
 ┌ Warning: 1 parameters had Pareto shape values 0.7 < k ≤ 1. Resulting importance sampling estimates are likely to be unstable.
 └ @ PSIS ~/.julia/packages/PSIS/...
 
-julia> model_weights(elpd_results; method=Stacking()) |> pairs
-pairs(::NamedTuple) with 2 entries:
-  :centered     => 3.50546e-31
-  :non_centered => 1.0
+julia> model_weights(elpd_results; method=Stacking())
+(centered = 0.0, non_centered = 1.0)
 ```
 
 Now we compute [`BootstrappedPseudoBMA`](@ref) weights for the same models:
 
-```jldoctest model_weights; setup = :(using Random; Random.seed!(94))
-julia> model_weights(elpd_results; method=BootstrappedPseudoBMA()) |> pairs
-pairs(::NamedTuple) with 2 entries:
-  :centered     => 0.492513
-  :non_centered => 0.507487
+```jldoctest model_weights; setup = :(using Random; Random.seed!(94)), filter = [r"(=\\s+0\\.\\d{2})\\d*" => s"\\1"]
+julia> model_weights(elpd_results; method=BootstrappedPseudoBMA())
+(centered = 0.492513, non_centered = 0.507487)
 ```
 
 # References

--- a/src/model_weights.jl
+++ b/src/model_weights.jl
@@ -29,7 +29,7 @@ See also: [`AbstractModelWeightsMethod`](@ref), [`compare`](@ref)
 
 Compute [`Stacking`](@ref) weights for two models:
 
-```jldoctest model_weights; filter = [r"└.*", r"(\\d+\\.\\d{3})\\d*" => s"\\1"]
+```jldoctest model_weights; filter = [r"└.*", r"(\\d+\\.\\d{3})\\d*" => s"\\1", r"(centered\\s*=\\s*)(?:0\\.0|[-+]?\\d+(?:\\.\\d+)?e-(?:1[5-9]|[2-9]\\d|1\\d{2,}))" => s"\\g<1>0.0"]
 julia> using ArviZExampleData
 
 julia> models = (


### PR DESCRIPTION
## Checklist

- [x] PR follows [official](https://github.com/arviz-devs/arviz/blob/main/CONTRIBUTING.md#pull-request-checklist) PR format.
- [x] The docs change is listed in the [Documentation](https://github.com/arviz-devs/PosteriorStats.jl/blob/main/CHANGELOG.md#Documentation) section of the changelog.
