### PR TITLE
Improve error message when specifying incorrect hdi method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Documentation
 
+## v0.4.11 (2026-06-19)
+
+### Features
+
+- Improved error message when calling `hdi` with an invalid method ([#100](https://github.com/arviz-devs/PosteriorStats.jl/pull/100))
+
 ## v0.4.10 (2026-06-18)
 
 ### Maintenance

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PosteriorStats"
 uuid = "7f36be82-ad55-44ba-a5c0-b8b5480d7aa5"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
 
 [deps]

--- a/src/hdi.jl
+++ b/src/hdi.jl
@@ -182,6 +182,14 @@ Base.@constprop :aggressive function hdi!(
     ndims(x) > 0 ||
         throw(ArgumentError("HDI cannot be computed for a 0-dimensional array."))
     isempty(x) && throw(ArgumentError("HDI cannot be computed for an empty array."))
+    if method isa Symbol && !hasproperty(HDI_ESTIMATION_METHODS, method)
+        throw(
+            ArgumentError(
+                "method `$method` not recognized;" *
+                " available HDI methods are $(keys(HDI_ESTIMATION_METHODS))."
+            )
+        )
+    end
     _method = _hdi_method(method, x, is_discrete; kwargs...)
     S = _hdi_eltype(_method, x)
     if ndims(x) < 3

--- a/test/hdi.jl
+++ b/test/hdi.jl
@@ -96,6 +96,11 @@ end
                 @test_throws ArgumentError hdi(fill(0.0); method)
             end
 
+            @testset "errors for invalid method" begin
+                @test_throws ArgumentError hdi(randn(2); method=:nonexistent)
+                @test_throws "method `nonexistent` not recognized" hdi(randn(2); method=:nonexistent)
+            end
+
             @testset "errors for prob not in (0, 1)" begin
                 x = randn(1_000)
                 @test_throws ArgumentError hdi(x; method, prob=-0.1)


### PR DESCRIPTION
Calling `hdi(...; method=:doesntexist)` currently gives a slightly cryptic error (on Julia >= 1.12, this is helped a bit by the new default error message for nonexistent NamedTuple indexing, but still doesn't point to the method keyword argument being the root cause). This is a little bit more friendly :-)