### PR TITLE
ci: use min-patch for the downgrade job's Julia version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
         downgrade:
           - false
         include:
-          - version: 'min'
+          - version: 'min-patch'
             os: ubuntu-latest
             arch: x64
             downgrade: true


### PR DESCRIPTION
#99 bumped setup-julia to v3, which changed `version: min` to resolve to the minimum major/minor but *latest* patch — we missed that this silently changed which Julia patch the downgrade job runs on. `min-patch` restores the true minimum-patch behavior the downgrade job actually needs.