### PR TITLE
docs: add compat entries for docs project dependencies

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -15,6 +15,12 @@ PosteriorStats = {path = ".."}
 
 [compat]
 ArviZExampleData = "0.3"
+Distributions = "0.25.57"
 Documenter = "1"
 DocumenterCitations = "1.2"
 DocumenterInterLinks = "1"
+LogExpFunctions = "1"
+MCMCDiagnosticTools = "0.3.4"
+PosteriorStats = "0.4.11"
+Statistics = "1"
+StatsBase = "0.34"


### PR DESCRIPTION
Splits the docs/Project.toml compat additions out of #107, which mixed them with an unrelated OrderedCollections compat bump in root Project.toml.

Compat bounds are copied from root Project.toml's existing entries for these deps (newest version listed) rather than pinned to the latest released version:

- Distributions = "0.25.57"
- LogExpFunctions = "1"
- MCMCDiagnosticTools = "0.3.4"
- PosteriorStats = "0.4.11"
- Statistics = "1"
- StatsBase = "0.34"

#107 is left as-is; once this merges, dependabot should rebase it and treat these as normal version bumps going forward.