### PR TITLE
ci: split downgrade testing into its own workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.downgrade && 'Downgrade / ' || '' }}Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -28,28 +28,14 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
-        downgrade:
-          - false
-        include:
-          - version: 'min-patch'
-            os: ubuntu-latest
-            arch: x64
-            downgrade: true
 
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
-        id: setup-julia
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: LinearAlgebra,Markdown,Printf,Random,Statistics,ArviZExampleData
-          julia_version: ${{ steps['setup-julia'].outputs.julia-version }}
-        if: ${{ matrix.downgrade }}
-        name: Downgrade dependencies to oldest supported versions
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,39 @@
+name: Downgrade
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  test:
+    name: Downgrade / Julia ${{ matrix.version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['lts']
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          mode: deps
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: false
+          force_latest_compatible_version: false
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info


### PR DESCRIPTION
- Move the conditional downgrade matrix leg out of \`CI.yml\` into a separate \`Downgrade.yml\`
- Downgrade workflow runs only against Julia \`lts\` with \`mode: deps\`, matching the rest of the fleet
- \`CI.yml\` goes back to a plain version matrix