### PR TITLE
ci: rebuild RCall in R-reference workflow to fix stale libR path

### DIFF
--- a/.github/workflows/r_reference.yml
+++ b/.github/workflows/r_reference.yml
@@ -44,5 +44,6 @@ jobs:
         run: |
           using Pkg
           Pkg.instantiate()
+          Pkg.build("RCall")
           include(joinpath(pwd(), "test", "reference", "runtests.jl"))
         shell: julia --color=yes --project=test/reference/ {0}


### PR DESCRIPTION
## Summary
- The `R-reference` workflow started failing on 2026-07-07 with `Could not find library /opt/R/4.6.0/lib/R/lib/libR.so`.
- Root cause: `julia-actions/cache` restores the Julia depot cache regardless of which R release is installed. The runner's R release moved from 4.6.0 (last successful run, 2026-06-22) to 4.6.1, but the cached RCall build artifacts still pointed at the old, now-missing `libR.so` path, and the workflow never rebuilds RCall.
- Fix: add `Pkg.build("RCall")` right after `Pkg.instantiate()`, so RCall always re-detects the currently installed R instead of trusting stale cached state — mirroring the existing `Pkg.build("Conda")` step in the same workflow.

## Test plan
- [x] Confirm the `R-reference` check on this PR passes
- [x] Confirm the run logs show `Pkg.build("RCall")` executing and no `Could not find library .../libR.so` error